### PR TITLE
Update readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -44,7 +44,7 @@ Learn about the various options:
 
 Finally, bootstrap your Rails app, for example:
 
-  ruby script/generate cucumber --rspec --capybara
+  ruby script/generate cucumber
 
 == Generating a Cucumber feature
 


### PR DESCRIPTION
When attempting to use the described --rspec and --capybara options I got the following errors:

```
/Users/jon/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/1.9.1/minitest/unit.rb:566:in `block in process_args': invalid option: --rspec (OptionParser::InvalidOption)
from /Users/jon/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/1.9.1/minitest/unit.rb:545:in `new'
from /Users/jon/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/1.9.1/minitest/unit.rb:545:in `process_args'
from /Users/jon/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/1.9.1/minitest/unit.rb:576:in `run'
from /Users/jon/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/1.9.1/minitest/unit.rb:492:in `block in autorun'
```

And

```
/Users/jon/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/1.9.1/minitest/unit.rb:566:in `block in process_args': invalid option: --capybara (OptionParser::InvalidOption)
from /Users/jon/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/1.9.1/minitest/unit.rb:545:in `new'
from /Users/jon/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/1.9.1/minitest/unit.rb:545:in `process_args'
from /Users/jon/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/1.9.1/minitest/unit.rb:576:in `run'
from /Users/jon/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/1.9.1/minitest/unit.rb:492:in `block in autorun'
```
