### PR TITLE
Endring i regexp for norsk "Given %{I am on #{page_name}}"

### DIFF
--- a/templates/install/step_definitions/web_steps_da.rb.erb
+++ b/templates/install/step_definitions/web_steps_da.rb.erb
@@ -3,7 +3,7 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "support", "paths"))
 
-Givet /^(?:at )jeg står på (.*)$/ do |page_name|
+Givet /^(?:|at )jeg står på (.*)$/ do |page_name|
   Given %{I am on #{page_name}}
 end
 

--- a/templates/install/step_definitions/web_steps_no.rb.erb
+++ b/templates/install/step_definitions/web_steps_no.rb.erb
@@ -3,7 +3,7 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "support", "paths"))
 
-Gitt /^(?:at )jeg står på (.*)$/ do |page_name|
+Gitt /^(?:|at )jeg står på (.*)$/ do |page_name|
   Given %{I am on #{page_name}}
 end
 


### PR DESCRIPTION
Jeg hadde behov for å si:
    Når jeg står på alfabetisk-siden for "a"

Denne ble ikke fanget av step-definisjonen i web_steps_no.rb som så slik ut:
    Gitt /^(?:at )jeg står på (.*)$/ do |page_name|
      Given %{I am on #{page_name}}
    end

Grunnen er at ^(?:at ) ikke matcher når "at" mangler. Så i denne commit-en har jeg endret dette til:
    Gitt /^(?:|at )jeg står på (.*)$/ do |page_name|

Endret for dansk også, som har samme språklige konstruksjon.

-martin
