### PR TITLE
Broken JS emulation when using most recent Capybara

### DIFF
--- a/lib/cucumber/rails/capybara_javascript_emulation.rb
+++ b/lib/cucumber/rails/capybara_javascript_emulation.rb
@@ -19,12 +19,12 @@ module Cucumber
       private
 
       def js_form(action, emulated_method, method = 'POST')
-        js_form = node.document.create_element('form')
+        js_form = native.document.create_element('form')
         js_form['action'] = action
         js_form['method'] = method
 
         if emulated_method and emulated_method.downcase != method.downcase
-          input = node.document.create_element('input')
+          input = native.document.create_element('input')
           input['type'] = 'hidden'
           input['name'] = '_method'
           input['value'] = emulated_method
@@ -36,17 +36,17 @@ module Cucumber
 
       def link_with_non_get_http_method?
         if ::Rails.version.to_f >= 3.0
-          tag_name == 'a' && node['data-method'] && node['data-method'] =~ /(?:delete|put|post)/
+          tag_name == 'a' && native['data-method'] && native['data-method'] =~ /(?:delete|put|post)/
         else
-          tag_name == 'a' && node['onclick'] && node['onclick'] =~ /var f = document\.createElement\('form'\); f\.style\.display = 'none';/
+          tag_name == 'a' && native['onclick'] && native['onclick'] =~ /var f = document\.createElement\('form'\); f\.style\.display = 'none';/
         end
       end
 
       def emulated_method
         if ::Rails.version.to_f >= 3.0
-          node['data-method']
+          native['data-method']
         else
-          node['onclick'][/m\.setAttribute\('value', '([^']*)'\)/, 1]
+          native['onclick'][/m\.setAttribute\('value', '([^']*)'\)/, 1]
         end
       end
     end


### PR DESCRIPTION
Hi Mate,

Just though that i would push this one up stream. Found that the #node method in Capybara::Driver::RackTest::Node is now gone in the most recent version of Capybara. You now need to call #native to get access to the "native" node object.

Cheers,
Chris

P.S. This is my first ever pull request. How did I do? ;)
