### PR TITLE
/^(?:|I )should see JSON:$/ is broken

### DIFF
--- a/templates/install/step_definitions/capybara_steps.rb.erb
+++ b/templates/install/step_definitions/capybara_steps.rb.erb
@@ -95,7 +95,7 @@ end
 Then /^(?:|I )should see JSON:$/ do |expected_json|
   require 'json'
   expected = JSON.pretty_generate(JSON.parse(expected_json))
-  actual   = JSON.pretty_generate(JSON.parse(response.body))
+  actual   = JSON.pretty_generate(JSON.parse(body))
   expected.should == actual
 end
 


### PR DESCRIPTION
response is nil in capybara and is not necessary, just use body to get the response json.
