### PR TITLE
Work with capybara 0.4

### DIFF
--- a/lib/cucumber/rails/capybara/select_dates_and_times.rb
+++ b/lib/cucumber/rails/capybara/select_dates_and_times.rb
@@ -4,7 +4,7 @@ module Cucumber
       module SelectDatesAndTimes
         def select_date(field, options = {})
           date        = Date.parse(options[:with])
-          base_dom_id = get_base_dom_id(field)
+          base_dom_id = get_base_dom_id_from_label_tag(field)
 
           find(:xpath, "//select[@id='#{base_dom_id}1i']").select(date.year.to_s)
           find(:xpath, "//select[@id='#{base_dom_id}2i']").select(date.strftime('%B'))
@@ -13,7 +13,7 @@ module Cucumber
       
         def select_time(field, options = {})
           time        = Time.zone.parse(options[:with])
-          base_dom_id = get_base_dom_id(field)
+          base_dom_id = get_base_dom_id_from_label_tag(field)
 
           find(:xpath, "//select[@id='#{base_dom_id}4i']").select(time.hour.to_s.rjust(2, '0'))
           find(:xpath, "//select[@id='#{base_dom_id}5i']").select(time.min.to_s.rjust(2,  '0'))
@@ -27,7 +27,7 @@ module Cucumber
         private
 
         # @example "event_starts_at_"
-        def get_base_dom_id(field)
+        def get_base_dom_id_from_label_tag(field)
           find(:xpath, "//label[contains(., '#{field}')]")['for'].gsub(/(1i)$/, '')
         end
       end


### PR DESCRIPTION
There's been a lot of attempts at trying to get the date-time helpers to work with Capybara 0.4, but I think I have the best solution yet. I'm fairly certain, though I haven't proven, that it should work with older versions of Capybara as well as I don't rely on the XPath library Capy uses, but rather the #find() method which is already kicking around.
