### PR TITLE
102 allow setting rails root

### DIFF
--- a/lib/cucumber/rails3.rb
+++ b/lib/cucumber/rails3.rb
@@ -1,7 +1,7 @@
 require 'cucumber/rails3/application'
 ENV["RAILS_ENV"] ||= "test"
-env = caller.detect{|f| f =~ /\/env\.rb:/}
-require File.expand_path(File.dirname(env) + '/../../config/environment')
+ENV["RAILS_ROOT"] ||= File.expand_path(File.dirname(caller.detect{|f| f =~ /\/env\.rb:/}) + '/../..')
+require File.expand_path(ENV["RAILS_ROOT"] + '/config/environment')
 require 'cucumber/rails3/action_controller'
 
 if defined?(ActiveRecord::Base)


### PR DESCRIPTION
This should fix the issue on how to load Rails on a dummy app to test engines. By default, it uses the same logic as before (find env.rb and expand path until config/environment), or the provided RAILS_ROOT + config/environment, if passed.
