### PR TITLE
Switched console info

### DIFF
--- a/templates/install/step_definitions/webrat_steps.rb.erb
+++ b/templates/install/step_definitions/webrat_steps.rb.erb
@@ -253,7 +253,7 @@ end
 Then /^(?:|I )should be on (.+)$/ do |page_name|
   current_path = URI.parse(current_url).path
   if current_path.respond_to? :should
-    current_path.should == path_to(page_name)
+    path_to(page_name).should == current_path
   else
     assert_equal path_to(page_name), current_path
   end


### PR DESCRIPTION
I expect to be on path /refinery, but I'm on /admin.

Old message:
expected: "/admin"
got: "/refinery" (using ==) (RSpec::Expectations::ExpectationNotMetError)

After this micropatch:
expected: "/refinery"
got: "/admin" (using ==) (RSpec::Expectations::ExpectationNotMetError)
