### PR TITLE
Remove database cleaner overrides because it fails when multiple ORMs are specified.

### DIFF
--- a/lib/cucumber/rails/hooks/database_cleaner.rb
+++ b/lib/cucumber/rails/hooks/database_cleaner.rb
@@ -4,22 +4,6 @@ begin
   require 'database_cleaner'
 
   Before do
-    begin
-      $__cucumber_global_database_cleaner_strategy ||= DatabaseCleaner.connections[0].strategy # There is no accessor on the DatabaseCleaner
-    rescue DatabaseCleaner::NoStrategySetError => e
-      e.message << "\nYou can set the strategy in your features/support/env.rb"
-    end
-  end
-
-  Before('~@no-txn', '~@selenium', '~@culerity', '~@celerity', '~@javascript') do
-    DatabaseCleaner.strategy = $__cucumber_global_database_cleaner_strategy
-  end
-
-  Before('@no-txn,@selenium,@culerity,@celerity,@javascript') do
-    DatabaseCleaner.strategy = :truncation
-  end
-
-  Before do
     # TODO: May have to patch DatabaseCleaner's Transaction class to do what we used to do:
     #   run_callbacks :setup if respond_to?(:run_callbacks)
     # IIRC There was a cucumber-rails ticket that added that to support multiple connections...


### PR DESCRIPTION
The example code in database_cleaner.rb breaks when you have multiple ORM strategies in database_cleaner. 

For example, we had :active_record and :mongo_mapper, and this code reset the :mongo_mapper strategy to active_record as that was what we specified first.

We could refactor this to work with multiple ORM strategies, but IMHO this should be in an example and not in a file that's not easily overridden. 
