### PR TITLE
DatabaseCleaner::Base#strategy no longer raises an exception.

### DIFF
--- a/lib/cucumber/rails/hooks/database_cleaner.rb
+++ b/lib/cucumber/rails/hooks/database_cleaner.rb
@@ -5,11 +5,6 @@ begin
 
   Before do
     $__cucumber_global_database_cleaner_strategy ||= DatabaseCleaner.connections[0].strategy
-    #begin
-    #  $__cucumber_global_database_cleaner_strategy ||= DatabaseCleaner.connections[0].strategy # There is no accessor on the DatabaseCleaner
-    #rescue DatabaseCleaner::NoStrategySetError => e
-    #  e.message << "\nYou can set the strategy in your features/support/env.rb"
-    #end
   end
 
   Before('~@no-txn', '~@selenium', '~@culerity', '~@celerity', '~@javascript') do


### PR DESCRIPTION
In the latest version of the gem `DatabaseCleaner - (0.6.6)`, `DatabaseCleaner::Base#strategy` no longer raises an exception - instead a `NullStrategy` is returned. 
