### PR TITLE
Only set Capybara.default_selector if Capybara is loaded

### DIFF
--- a/templates/install/support/capybara.rb
+++ b/templates/install/support/capybara.rb
@@ -2,4 +2,4 @@
 # order to ease the transition to Capybara we set the default here. If you'd
 # prefer to use XPath just remove this line and adjust any selectors in your
 # steps to use the XPath syntax.
-Capybara.default_selector = :css
+Capybara.default_selector = :css if Object.const_defined?("Capybara")


### PR DESCRIPTION
Hi... this fixes https://github.com/aslakhellesoy/cucumber-rails/issues/125. I'm not sure it's the right way to do it, since you already have an option to disable capybara manually - but I think if you're going to default that option to on, you should either require the capybara gem or do something like this, so the default install doesn't abort with an error.
