### PR TITLE
fixed date-localization bug

### DIFF
--- a/lib/cucumber/rails/capybara/select_dates_and_times.rb
+++ b/lib/cucumber/rails/capybara/select_dates_and_times.rb
@@ -7,7 +7,7 @@ module Cucumber
           base_dom_id = get_base_dom_id_from_label_tag(field)
 
           find(:xpath, "//select[@id='#{base_dom_id}_1i']").select(date.year.to_s)
-          find(:xpath, "//select[@id='#{base_dom_id}_2i']").select(date.strftime('%B'))
+          find(:xpath, "//select[@id='#{base_dom_id}_2i']").select(I18n.l date, :format => '%B')
           find(:xpath, "//select[@id='#{base_dom_id}_3i']").select(date.day.to_s)
         end
       


### PR DESCRIPTION
There is a problem with localization when working with Capybara and using the date-selector steps. When the rails-app under test is in a different language than english the month isn't localized correctly in the date-step.
