### PR TITLE
adjust select_date, select_time xpaths so they work when scoped in the document

### DIFF
--- a/features/select_dates.feature
+++ b/features/select_dates.feature
@@ -97,3 +97,45 @@ Feature: Select dates
       1 scenario (1 passed)
       6 steps (6 passed)
       """
+      
+  Scenario: Select correct date when scoped
+    Given I successfully run `bundle exec rails g scaffold appointment name:string when:date`
+    And I write to "features/create_appointment.feature" with:
+      """
+      Feature: Create appointments
+        Scenario: Constitution on May 17
+          Given I am on the new appointment page
+          And I fill in "Norway's constitution" for "Name"
+          And I select "2009-02-20" as the "When" date
+          And I select "2009-03-20" as the "When" date within "#extra"
+          And I press "Create Appointment"
+          Then I should see "Norway's constitution"
+          And I should see "2009-02-20"
+      """
+    And I write to "app/views/appointments/_form.html.erb" with:
+      """
+      <%= form_for(@appointment) do |f| %>
+        <div class="field">
+          <%= f.label :name %><br />
+          <%= f.text_field :name %>
+        </div>
+        <div class="field">
+          <%= f.label :when, :for => "appointment_when_1i" %><br />
+          <%= f.date_select :when %>
+        </div>
+        <div class="actions">
+          <%= f.submit %>
+        </div>
+      <% end %>
+      <div id="extra">
+        <%= label_tag 'extra_when_1i', 'When' %>
+        <%= date_select "extra", "when" %>
+      </div>
+      """
+    When I run `bundle exec rake db:migrate`
+    And I run `bundle exec rake cucumber`
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      7 steps (7 passed)
+      """

--- a/lib/cucumber/rails/capybara/select_dates_and_times.rb
+++ b/lib/cucumber/rails/capybara/select_dates_and_times.rb
@@ -6,17 +6,17 @@ module Cucumber
           date        = Date.parse(options[:with])
           base_dom_id = get_base_dom_id_from_label_tag(field)
 
-          find(:xpath, "//select[@id='#{base_dom_id}_1i']").select(date.year.to_s)
-          find(:xpath, "//select[@id='#{base_dom_id}_2i']").select(I18n.l date, :format => '%B')
-          find(:xpath, "//select[@id='#{base_dom_id}_3i']").select(date.day.to_s)
+          find(:xpath, ".//select[@id='#{base_dom_id}_1i']").select(date.year.to_s)
+          find(:xpath, ".//select[@id='#{base_dom_id}_2i']").select(I18n.l date, :format => '%B')
+          find(:xpath, ".//select[@id='#{base_dom_id}_3i']").select(date.day.to_s)
         end
       
         def select_time(field, options = {})
           time        = Time.zone.parse(options[:with])
           base_dom_id = get_base_dom_id_from_label_tag(field)
 
-          find(:xpath, "//select[@id='#{base_dom_id}_4i']").select(time.hour.to_s.rjust(2, '0'))
-          find(:xpath, "//select[@id='#{base_dom_id}_5i']").select(time.min.to_s.rjust(2,  '0'))
+          find(:xpath, ".//select[@id='#{base_dom_id}_4i']").select(time.hour.to_s.rjust(2, '0'))
+          find(:xpath, ".//select[@id='#{base_dom_id}_5i']").select(time.min.to_s.rjust(2,  '0'))
         end
       
         def select_datetime(field, options = {})
@@ -28,7 +28,7 @@ module Cucumber
 
         # @example "event_starts_at_"
         def get_base_dom_id_from_label_tag(field)
-          find(:xpath, "//label[contains(., '#{field}')]")['for'].gsub(/(_[1-5]i)$/, '')
+          find(:xpath, ".//label[contains(., '#{field}')]")['for'].gsub(/(_[1-5]i)$/, '')
         end
       end
     end


### PR DESCRIPTION
This adjusts the xpaths used in the select_date and select_time methods so that they are relative to the current node rather than document wide.  This enables them to work properly when scoped within the document.  Test added as well
