### PR TITLE
removed empty_folder from FeaturesGenerator to prevent revokation of step

### DIFF
--- a/lib/generators/cucumber/feature/feature_generator.rb
+++ b/lib/generators/cucumber/feature/feature_generator.rb
@@ -13,7 +13,6 @@ module Cucumber
     end    
 
     def generate
-      empty_directory 'features/step_definitions'
       template 'feature.erb', "features/manage_#{plural_name}.feature"
       template 'steps.erb', "features/step_definitions/#{singular_name}_steps.rb"
       gsub_file 'features/support/paths.rb', /'\/'/mi do |match|


### PR DESCRIPTION
removed empty_folder from FeaturesGenerator to prevent revokation of step_definitions folder on destroy
