### PR TITLE
Broken link in the USAGE file of the features generator

### DIFF
--- a/lib/generators/cucumber/feature/USAGE
+++ b/lib/generators/cucumber/feature/USAGE
@@ -1,7 +1,7 @@
 Description:
     Generates a skeleton for a new feature. Both a simple .feature file and
     a steps.rb file is generated. This generator should be used with moderation.
-    See http://github.com/aslakhellesoy/cucumber/wikis/feature-coupled-steps-antipattern
+    See https://github.com/cucumber/cucumber/wiki/Feature-Coupled-Steps-(Antipattern)
     for details about the dangers involved.
 
     This generator can take an optional list of attribute pairs similar to Rails'


### PR DESCRIPTION
Fixed a broken link pointing the 'Feature Coupled Steps (Antipattern)' in the USAGE file of the features generator 
