### PR TITLE
Require features by default in the generated cucumber.yml

### DIFF
--- a/lib/generators/cucumber/install/templates/config/cucumber.yml.erb
+++ b/lib/generators/cucumber/install/templates/config/cucumber.yml.erb
@@ -1,7 +1,7 @@
 <%%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags --require features ~@wip"
 %>
 default: <%= spork? ? '--drb ' : '' %><%%= std_opts %> features
 wip: <%= spork? ? '--drb ' : '' %>--tags @wip:3 --wip features


### PR DESCRIPTION
The generated cucumber.yml doesn't allow for easily running a single cucumber feature or scenario as the features folder is not required. I've added a require in the standard options passed to cucumber.
