### PR TITLE
Removed mention of web_steps in install generator

### DIFF
--- a/lib/generators/cucumber/install/USAGE
+++ b/lib/generators/cucumber/install/USAGE
@@ -8,6 +8,3 @@ Examples:
     `rails generate cucumber:install`
 
     `rails generate cucumber:install --help`
-
-    You can also provide a language argument for localized web_steps:
-    `rails generate cucumber:install de`


### PR DESCRIPTION
Since the training wheels came off.
