### PR TITLE
Turn off shared DB connection when not using transactional fixtures in JS env 

### DIFF
--- a/lib/cucumber/rails/hooks/active_record.rb
+++ b/lib/cucumber/rails/hooks/active_record.rb
@@ -6,14 +6,16 @@ if defined?(ActiveRecord::Base)
       self.shared_connection || retrieve_connection
     end
   end
-  
+
   Before('@javascript') do
-    # Forces all threads to share a connection on a per-model basis,
-    # as connections may vary per model as per establish_connection. This works
-    # on Capybara because it starts the web server in a thread.
-    ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
-    ActiveRecord::Base.descendants.each do |model|
-      model.shared_connection = model.connection
+    if Cucumber::Rails::World.use_transactional_fixtures
+      # Forces all threads to share a connection on a per-model basis,
+      # as connections may vary per model as per establish_connection. This works
+      # on Capybara because it starts the web server in a thread.
+      ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
+      ActiveRecord::Base.descendants.each do |model|
+        model.shared_connection = model.connection
+      end
     end
   end
 

--- a/spec/cucumber/rails/hooks/active_record_spec.rb
+++ b/spec/cucumber/rails/hooks/active_record_spec.rb
@@ -1,0 +1,54 @@
+# -*- encoding: utf-8 -*-
+
+require 'spec_helper'
+require 'cucumber'
+
+require 'rails'
+require 'active_record'
+
+describe ActiveRecord::Base do
+
+  class QuickCallback
+    @@callbacks = Hash.new {|h,k| h[k] = []}
+    def self.add_callback(name, block)
+      @@callbacks[name] << block
+    end
+
+    def self.run!(name)
+      @@callbacks[name].map(&:call)
+    end
+  end
+
+  class Object
+    def Before(name, &block)
+      QuickCallback.add_callback(name, block)
+    end
+  end
+
+  module Cucumber
+    module Rails
+      class World
+        cattr_accessor :use_transactional_fixtures
+      end
+    end
+  end
+  require 'lib/cucumber/rails/hooks/active_record'
+
+  def mock_active_record_retrieve_connection(times=1)
+    ActiveRecord::Base.should_receive(:retrieve_connection).exactly(times).times.and_return(true)
+  end
+
+  it 'should set a shared_connection when use_transactional_fixtures is false' do
+    mock_active_record_retrieve_connection(3)
+    Cucumber::Rails::World.use_transactional_fixtures = false
+    QuickCallback.run!('@javascript')
+    3.times { ActiveRecord::Base.connection }
+  end
+
+  it 'should NOT set a shared_connection when use_transactional_fixtures is true' do
+    mock_active_record_retrieve_connection
+    Cucumber::Rails::World.use_transactional_fixtures = true
+    QuickCallback.run!('@javascript')
+    3.times { ActiveRecord::Base.connection }
+  end
+end

--- a/spec/cucumber/web/tableish_spec.rb
+++ b/spec/cucumber/web/tableish_spec.rb
@@ -2,7 +2,6 @@
 
 require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper")
 
-def World(*a); end
 require 'cucumber/web/tableish'
 
 module Cucumber

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,3 +3,5 @@ gem 'rspec'
 require 'rspec/autorun'
 
 require 'ammeter/init'
+
+def World(*a); end


### PR DESCRIPTION
We had a problem where shared_connection would cause ActiveRecord to sometimes try and nest transactions because it maintains its own mapping of threads to DB connections (see def connection in [activerecord]/lib/active_record/connection_adapters/abstract/connection_pool.rb), so we just turned shared_connection off if use_transactional_fixtures is set to false. We wish we could offer a more comprehensive solution, but thought we'd offer this as better than nothing.
