### PR TITLE
allow ability to use deletion as a javascript database strategy

### DIFF
--- a/features/choose_javascript_database_strategy.feature
+++ b/features/choose_javascript_database_strategy.feature
@@ -1,9 +1,9 @@
 @announce
 Feature: Choose javascript database strategy
 
-  When running a scenario with the @javascript tag, Capybara will fire up a web server 
+  When running a scenario with the @javascript tag, Capybara will fire up a web server
   in the same process in a separate thread to your cukes. By default, this means ActiveRecord will give it a
-  separate database connection, which in turn means data you put into your database from 
+  separate database connection, which in turn means data you put into your database from
   Cucumber step definitions (e.g. using FactoryGirl) won't be visible to the web server
   until the database transaction is committed.
 
@@ -18,20 +18,23 @@ Feature: Choose javascript database strategy
   your database, but you run the risk of the two threads stomping on one another as they
   talk to the database.
 
-  Right now, the default behavior which works for 80% of cucumber-rails users is to use 
+  Right now, the default behavior which works for 80% of cucumber-rails users is to use
   the shared connection patch, but you can override this by telling cucumber-rails which
   strategy to use for javascript scenarios.
+
+  The deletion strategy can be quicker for situations where truncation causes locks which
+  has been reported by some Oracle users.
 
   Background:
     Given I have created a new Rails 3 app and installed cucumber-rails
     And I have a "Widget" ActiveRecord model object
-    And I append to "features/env.rb" with:
+
+  Scenario: Set the strategy to truncation and run a javascript scenario.
+    Given I append to "features/env.rb" with:
       """
       Cucumber::Rails::Database.javascript_strategy = :truncation
       """
-
-  Scenario: Set the strategy to truncation and run a javascript scenario.
-    Given I write to "features/widgets.feature" with:
+    And I write to "features/widgets.feature" with:
       """
       @javascript
       Feature:
@@ -61,3 +64,39 @@ Feature: Choose javascript database strategy
        2 scenarios (2 passed)
        5 steps (5 passed)
        """
+
+  Scenario: Set the strategy to deletion and run a javascript scenario.
+    Given I append to "features/env.rb" with:
+      """
+      Cucumber::Rails::Database.javascript_strategy = :deletion
+      """
+    And I write to "features/widgets.feature" with:
+      """
+      @javascript
+      Feature:
+        Background:
+          Given I have created 2 widgets
+
+        Scenario:
+          When I create 3 widgets
+          Then I should have 5 widgets
+
+        Scenario:
+          Then I should have 2 widgets
+      """
+    And I write to "features/step_definitions/widget_steps.rb" with:
+      """
+      Given /created? (\d) widgets/ do |num|
+        num.to_i.times { Widget.create! }
+      end
+
+      Then /should have (\d) widgets/ do |num|
+        Widget.count.should == num.to_i
+      end
+      """
+    When I run the cukes
+    Then it should pass with:
+       """
+       2 scenarios (2 passed)
+       5 steps (5 passed)
+     """

--- a/lib/cucumber/rails/database.rb
+++ b/lib/cucumber/rails/database.rb
@@ -36,7 +36,8 @@ module Cucumber
           {
             :truncation => TruncationStrategy,
             :shared_connection => SharedConnectionStrategy,
-            :transaction => SharedConnectionStrategy
+            :transaction => SharedConnectionStrategy,
+            :deletion => DeletionStrategy
           }
         end
 
@@ -68,16 +69,28 @@ module Cucumber
         end
       end
 
-      class TruncationStrategy
-        def before_js
+      class Strategy
+        def before_js(strategy)
           @original_strategy = DatabaseCleaner.connections.first.strategy # that feels like a nasty hack
-          DatabaseCleaner.strategy = :truncation
+          DatabaseCleaner.strategy = strategy
         end
 
         def before_non_js
           return unless @original_strategy
           DatabaseCleaner.strategy = @original_strategy
           @original_strategy = nil
+        end
+      end
+
+      class TruncationStrategy < Strategy
+        def before_js
+          super :truncation
+        end
+      end
+
+      class DeletionStrategy < Strategy
+        def before_js
+          super :deletion
         end
       end
 


### PR DESCRIPTION
For oracle users, using deletion strategy can be faster then truncation since truncation has a tendency to lock the db. Adding ability to specify deletion for javascript database strategy.
