### PR TITLE
Add dependency status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cucumber-Rails
 
 [![Build Status](https://secure.travis-ci.org/cucumber/cucumber-rails.png)](http://travis-ci.org/cucumber/cucumber-rails)
+[![Dependency Status](https://gemnasium.com/cucumber/cucumber-rails.png)](https://gemnasium.com/cucumber/cucumber-rails)
 
 Cucumber-Rails brings Cucumber to Rails 3.x. For Rails 2x support, see the [Cucumber Wiki](https://github.com/cucumber/cucumber/wiki/Ruby-on-Rails). 
 


### PR DESCRIPTION
Via Gemnasium. This indicates whether cucumber-rails' dependency requirements are up-to-date with the latest versions or if there is potential for upgrade.
