### PR TITLE
update misleading capybara generator

### DIFF
--- a/lib/generators/cucumber/install/templates/support/capybara.rb
+++ b/lib/generators/cucumber/install/templates/support/capybara.rb
@@ -1,5 +1,4 @@
-# Capybara defaults to XPath selectors rather than Webrat's default of CSS3. In
-# order to ease the transition to Capybara we set the default here. If you'd
-# prefer to use XPath just remove this line and adjust any selectors in your
-# steps to use the XPath syntax.
-Capybara.default_selector = :css
+# Capybara and Webrat default to CSS3 selectors rather than XPath.
+# If you'd prefer to use XPath, just uncomment this line and adjust any
+# selectors in your steps to use the XPath syntax.
+# Capybara.default_selector = :xpath


### PR DESCRIPTION
Capybara uses CSS as default selector since version 0.3.9 (June 2010).

And cucumber-rails has a hardcoded dependency on capybara >= 1.1.2 anyway,

so ...

I fixed the misleading message in the generator, because xpath is not the default as it turns out.
