### PR TITLE
Fix #202 - warning msg should include require: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Cucumber-Rails brings Cucumber to Rails 3.x. For Rails 2x support, see the [Cucu
 Before you can use the generator, add the gem to your project's Gemfile as follows:
 
     group :test do
-      gem 'cucumber-rails'
+      gem 'cucumber-rails', :require => false
       # database_cleaner is not required, but highly recommended
       gem 'database_cleaner'
     end

--- a/features/fixing_bundler_pre.feature
+++ b/features/fixing_bundler_pre.feature
@@ -20,5 +20,6 @@ Feature: Fixing Bundler Pre
       1 step (1 passed)
       """
     And the output should contain "WARNING:"
+    And the output should contain ":require => false"
 
 

--- a/lib/cucumber/rails.rb
+++ b/lib/cucumber/rails.rb
@@ -25,5 +25,6 @@ if env_caller
 
 else
   warn "WARNING: Cucumber-rails required outside of env.rb.  The rest of loading is being deferred until env.rb is called.
-  To avoid this warning, move 'gem cucumber-rails' under only group :test in your Gemfile"
+  To avoid this warning, move 'gem \'cucumber-rails\', :require => false' under only group :test in your Gemfile. 
+  If already in the :test group, be sure you are specifying ':require => false'."
 end


### PR DESCRIPTION
Update docs as well as warning message to make it clear that
the gem should be in the :test group and marked with
:require => false
