### PR TITLE
Remove useless "gem 'rspec'"

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'rubygems'
-gem 'rspec'
 require 'rspec/autorun'
 
 require 'ammeter/init'


### PR DESCRIPTION
Can't see any need for the line => get rid of it.
