### PR TITLE
Fix the build - Remove 1.9.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 rvm: 
   - 1.9.3
-  - 1.9.2
 # whitelist
 branches:
   only:


### PR DESCRIPTION
As noted in #225. 

Ruby 1.9.2 support is breaking the build and I don't care enough to work out why. This pull request just removes support for Ruby 1.9.2.

Any objections?
