### PR TITLE
Depend upon the generic test:prepare task

### DIFF
--- a/lib/generators/cucumber/install/templates/tasks/cucumber.rake.erb
+++ b/lib/generators/cucumber/install/templates/tasks/cucumber.rake.erb
@@ -9,19 +9,19 @@ begin
   require 'cucumber/rake/task'
 
   namespace :cucumber do
-    Cucumber::Rake::Task.new({:ok => 'db:test:prepare'}, 'Run features that should pass') do |t|
+    Cucumber::Rake::Task.new({:ok => 'test:prepare'}, 'Run features that should pass') do |t|
       t.binary = vendored_cucumber_bin # If nil, the gem's binary is used.
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'default'
     end
 
-    Cucumber::Rake::Task.new({:wip => 'db:test:prepare'}, 'Run features that are being worked on') do |t|
+    Cucumber::Rake::Task.new({:wip => 'test:prepare'}, 'Run features that are being worked on') do |t|
       t.binary = vendored_cucumber_bin
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'wip'
     end
 
-    Cucumber::Rake::Task.new({:rerun => 'db:test:prepare'}, 'Record failing features and run only them if any exist') do |t|
+    Cucumber::Rake::Task.new({:rerun => 'test:prepare'}, 'Record failing features and run only them if any exist') do |t|
       t.binary = vendored_cucumber_bin
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'rerun'
@@ -45,8 +45,8 @@ begin
     STDERR.puts "*** The 'features' task is deprecated. See rake -T cucumber ***"
   end
 
-  # In case we don't have ActiveRecord, append a no-op task that we can depend upon.
-  task 'db:test:prepare' do
+  # In case we don't have the generic Rails test:prepare hook, append a no-op task that we can depend upon.
+  task 'test:prepare' do
   end
 
   task :stats => 'cucumber:statsetup'


### PR DESCRIPTION
Judging by the discussion on [rspec-rails #663](https://github.com/rspec/rspec-rails/issues/663), the best thing to hook into for preparing the environment prior to running tests is `test:prepare`. Here's a quick fix to make that so.
