### PR TITLE
Allow users to disable database_cleaner hooks

### DIFF
--- a/features/disable_automatic_database_cleaning.feature
+++ b/features/disable_automatic_database_cleaning.feature
@@ -1,0 +1,55 @@
+Feature: Disable automatic database cleaning
+
+  By default, a set of Before/After hooks are installed to
+  invoke database_cleaner on every scenario except those tagged
+  "@no-database-cleaner". Sometimes when a user is switching between
+  cleaning strategies, this can initiate an undesired database
+  transaction.
+
+  To avoid the need for users making frequent strategy switches to apply
+  this tag, a configuration option is provided so that the user can
+  control the invocation of database_cleaner explicitly.
+
+  Scenario: Disabling automatic cleaning
+    Given I have created a new Rails 3 app and installed cucumber-rails
+    And I append to "features/env.rb" with:
+      """
+      Cucumber::Rails::Database.autorun_database_cleaner = false
+      """
+    And I write to "features/widgets.feature" with:
+      """
+      Feature: Create widgets
+        Scenario: Create 3 widgets
+          When I create 3 widgets
+          Then I should have 3 widgets
+
+        Scenario: Create 5 widgets
+          When I create 5 widgets
+          Then I should have 8 widgets
+      """
+    And I successfully run `rails generate model widget name:string`
+    And I write to "features/step_definitions/widget_steps.rb" with:
+      """
+      Given /^I have (\d+) widgets$/ do |n|
+        n.to_i.times do |i|
+          Widget.create! :name => "Widget #{Widget.count + i}"
+        end
+      end
+
+      When /^I create (\d+) widgets$/ do |n|
+        n.to_i.times do |i|
+          Widget.create! :name => "Widget #{Widget.count + i}"
+        end
+      end
+
+      Then /^I should have (\d+) widgets$/ do |n|
+        Widget.count.should == n.to_i
+      end
+      """
+    And I run `bundle exec rake db:migrate`
+    And I run `bundle exec rake cucumber`
+    Then it should pass with:
+       """
+       2 scenarios (2 passed)
+       4 steps (4 passed)
+       """

--- a/lib/cucumber/rails/database.rb
+++ b/lib/cucumber/rails/database.rb
@@ -8,6 +8,8 @@ module Cucumber
 
       class << self
 
+        attr_accessor :autorun_database_cleaner
+
         def javascript_strategy=(args)
           strategy, *strategy_opts = args
           strategy_type =
@@ -108,6 +110,7 @@ module Cucumber
       end
 
       Database.javascript_strategy = :truncation
+      Database.autorun_database_cleaner = true
     end
   end
 end

--- a/lib/cucumber/rails/hooks/database_cleaner.rb
+++ b/lib/cucumber/rails/hooks/database_cleaner.rb
@@ -2,11 +2,11 @@ begin
   require 'database_cleaner'
 
   Before('~@no-database-cleaner') do
-    DatabaseCleaner.start
+    DatabaseCleaner.start if Cucumber::Rails::Database.autorun_database_cleaner
   end
 
   After('~@no-database-cleaner') do
-    DatabaseCleaner.clean
+    DatabaseCleaner.clean if Cucumber::Rails::Database.autorun_database_cleaner
   end
 
 rescue LoadError => ignore_if_database_cleaner_not_present


### PR DESCRIPTION
Per the discussion in #215, this PR provides an option controlling the automatic invocation of `DatabaseCleaner.start` before every scenario, and `DatabaseCleaner.clean` afterwards (it defaults to true, naturally):

``` ruby
# features/support/env.rb
# ...
Cucumber::Rails::Database.autorun_database_cleaner = false
```

I added the option as an accessor on `Cucumber::Rails::Database` following the example of `.javascript_strategy` - it seemed the most natural place for it to live, but I'm happy to take alternative suggestions. :)

Cheers,
Simon

(p.s. the failing scenario is broken in master, too - wasn't me guv, honest.)
