### PR TITLE
Fix javascript cleaning strategy

### DIFF
--- a/lib/cucumber/rails/database.rb
+++ b/lib/cucumber/rails/database.rb
@@ -31,6 +31,10 @@ module Cucumber
           @strategy.before_non_js
         end
 
+        def after
+          @strategy.after
+        end
+
       private
 
         def map
@@ -61,6 +65,10 @@ module Cucumber
         end
 
         def before_non_js
+          # no-op
+        end
+
+        def after
           return unless @original_strategy
           DatabaseCleaner.strategy = @original_strategy
           @original_strategy = nil

--- a/lib/cucumber/rails/hooks/active_record.rb
+++ b/lib/cucumber/rails/hooks/active_record.rb
@@ -6,12 +6,16 @@ if defined?(ActiveRecord::Base)
       self.shared_connection || retrieve_connection
     end
   end
-  
+
   Before('@javascript') do
     Cucumber::Rails::Database.before_js
   end
 
   Before('~@javascript') do
     Cucumber::Rails::Database.before_non_js
+  end
+
+  After do
+    Cucumber::Rails::Database.after
   end
 end


### PR DESCRIPTION
If any non-JS scenarios run after at least two consecutive JS scenarios, the strategy will not be set correctly. This is because after a JS scenario, it does not reset to the original strategy, and on the second consecutive JS scenario, it sets `original_strategy` to whatever it is already, which happens to still be the JS-specific strategy from the previous scenario run.

```
Given: strategy = :transaction
       javascript_strategy = :truncation

Type   │ original_strategy set to
───────┼─────────────────────────
non-JS │ nil
JS     │ :transaction
non-JS │ nil
JS     │ :transaction
JS     │ :truncation
non-JS │ :truncation
```

The included tests fail on master, which shows that the above is true.
