### PR TITLE
Rails 4.0.0-beta ActionController::Integration deprecation fix

### DIFF
--- a/lib/cucumber/rails/world.rb
+++ b/lib/cucumber/rails/world.rb
@@ -6,7 +6,7 @@ end
 
 module Cucumber #:nodoc:
   module Rails #:nodoc:
-    class World < ActionController::IntegrationTest #:nodoc:
+    class World < ActionDispatch::IntegrationTest #:nodoc:
       include Rack::Test::Methods
       include ActiveSupport::Testing::SetupAndTeardown if ActiveSupport::Testing.const_defined?("SetupAndTeardown")
 


### PR DESCRIPTION
I don't necessarily expect this to get accepted because I did not create a feature per the instructions. I'm not entirely sure how that would be possible just yet without Rails4 being released. I'd be happy to do so with some guidance though. At minimum, someone that also sees the deprecation of ActionController::Integration in Rails 4 can use this fork temporarily until Rails 4 is released and it is worth creating a Rails4 branch with all the necessary modifications.

It is worth noting this does work in Rails 3 as ActionController::Integration is also available within ActionDispatch::Integration already as well.
