### PR TITLE
Fixes broken Gemspec due to renaming of files.

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -14,14 +14,14 @@ Gem::Specification.new do |s|
   s.email = %q{cukes@googlegroups.com}
   s.extra_rdoc_files = [
     "LICENSE",
-     "README.rdoc"
+     "README.md"
   ]
   s.files = [
     ".gitignore",
      "HACKING.rdoc",
-     "History.txt",
+     "History.md",
      "LICENSE",
-     "README.rdoc",
+     "README.md",
      "Rakefile",
      "VERSION",
      "config/.gitignore",


### PR DESCRIPTION
The README and History files were changed to markdown format, but the old filenames were hard coded in the Gemspec. This updates the filenames to the new markdown filenames and removes the warning when doing a bundle install.
