### PR TITLE
Allow use with Rails 4

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('cucumber', '>= 1.2.0')
   s.add_runtime_dependency('nokogiri', '>= 1.5.0')
   s.add_runtime_dependency('capybara', '>= 1.1.2')
-  s.add_runtime_dependency('rails', '~> 3.0')
+  s.add_runtime_dependency('rails', '>= 3.0')
 
   # Main development dependencies
   s.add_development_dependency('rake', '>= 0.9.2.2')


### PR DESCRIPTION
1.3.1 added a dependency on Rails 3 specifically, even though it works with Rails 4 and incorporates some pull requests (e.g. #234) specifically to address Rails 4 issues. This pull request allows Rails 4 as well.
