### PR TITLE
Describe configuration option 'autorun_database_cleaner' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ With Rake:
 Without Rake:
 
     [bundle exec] cucumber
+    
+## Configuration options
+
+By default, cucumber-rails runs `DatabaseCleaner.start` and `DatabaseCleaner.clean` before and after your scenarios. You can disable this behaviour like so:
+
+    # features/support/env.rb
+    # ...
+    Cucumber::Rails::Database.autorun_database_cleaner = false
 
 ## Bugs and feature requests
 


### PR DESCRIPTION
Issues #215 and #232 resulted in adding a configuration option to
disable the by-default-usage of DatabaseCleaner:

Cucumber::Rails::Database.autorun_database_cleaner = false

This has to go into the README so that users can easily learn about
it. Currently Google finds the related issues first, which is not
optimal.
