### PR TITLE
Added mime-types runtime dependency as bundle install was failing

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('cucumber', ['>= 1.3.8', '< 2'])
   s.add_runtime_dependency('nokogiri', '~> 1.5')
   s.add_runtime_dependency('rails', ['>= 3', '< 5'])
+  s.add_runtime_dependency('mime-types', '~> 1.16')
 
   # Main development dependencies
   s.add_development_dependency('ammeter', '>= 0.2.9')


### PR DESCRIPTION
After cloning the repository bundle install was failing.

This was discussed here: https://groups.google.com/forum/#!topic/ruby-bundler/tQICmCYIAbI
and an issue raided here: https://github.com/bundler/bundler/issues/2740

By adding the mime-types runtime dependency the issue is fixed.
