### PR TITLE
Ensure dependency on DatabaseCleaner is not required

### DIFF
--- a/lib/cucumber/rails/hooks/active_record.rb
+++ b/lib/cucumber/rails/hooks/active_record.rb
@@ -8,14 +8,14 @@ if defined?(ActiveRecord::Base)
   end
 
   Before('@javascript') do
-    Cucumber::Rails::Database.before_js
+    Cucumber::Rails::Database.before_js if Cucumber::Rails::Database.autorun_database_cleaner
   end
 
   Before('~@javascript') do
-    Cucumber::Rails::Database.before_non_js
+    Cucumber::Rails::Database.before_non_js if Cucumber::Rails::Database.autorun_database_cleaner
   end
 
   After do
-    Cucumber::Rails::Database.after
+    Cucumber::Rails::Database.after if Cucumber::Rails::Database.autorun_database_cleaner
   end
 end


### PR DESCRIPTION
This commit builds on dbe2091 and ensures DatabaseCleaner is not 
required when Cucumber::Rails::Database.autorun_database_cleaner = true
