### PR TITLE
Add annotations configuration in generator

### DIFF
--- a/features/annotations.feature
+++ b/features/annotations.feature
@@ -1,0 +1,23 @@
+@requires-rails-version-42
+Feature: Annotations
+
+  I order to track my development progress
+  As a developer
+  I should be able to list annotations in my features
+
+  Background:
+    Given I have created a new Rails app "test-app" with no database and installed cucumber-rails
+    And I write to "features/tests.feature" with:
+      """
+      Feature: Tests
+        Scenario: Tests
+          # TODO: When I go to the products page
+      """
+
+  Scenario: See annotations in .feature file
+    When I run `bundle exec rake notes`
+    Then it should pass with:
+      """
+      features/tests.feature:
+        * [ 3] [TODO] When I go to the products page
+      """

--- a/features/support/version_hooks.rb
+++ b/features/support/version_hooks.rb
@@ -1,0 +1,12 @@
+module VersionHooksHelper
+  def rails_version
+    @rails_version ||= `bundle exec rails --version`.match(/[\d.]+$/).to_s
+  end
+end
+
+Before '@requires-rails-version-42' do
+  extend VersionHooksHelper
+  if Gem::Version.new(rails_version) < Gem::Version.new('4.2')
+    skip_this_scenario
+  end
+end

--- a/lib/generators/cucumber/install/templates/tasks/cucumber.rake.erb
+++ b/lib/generators/cucumber/install/templates/tasks/cucumber.rake.erb
@@ -35,6 +35,15 @@ begin
       ::STATS_DIRECTORIES << %w(Cucumber\ features features) if File.exist?('features')
       ::CodeStatistics::TEST_TYPES << "Cucumber features" if File.exist?('features')
     end
+
+    task :annotations_setup do
+      Rails.application.configure do
+        if config.respond_to?(:annotations)
+          config.annotations.directories << 'features'
+          config.annotations.register_extensions('feature') { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
+        end
+      end
+    end
   end
   desc 'Alias for cucumber:ok'
   task :cucumber => 'cucumber:ok'
@@ -50,6 +59,8 @@ begin
   end
 
   task :stats => 'cucumber:statsetup'
+
+  task :notes => 'cucumber:annotations_setup'
 rescue LoadError
   desc 'cucumber rake task not available (cucumber not installed)'
   task :cucumber do


### PR DESCRIPTION
For Rails 4.0+, the generator will add configuration entries to
config/environments/development.rb to include Cucumber's features
directory and .feature files in the "rake notes" run.