### PR TITLE
Depend on railties instead of rails

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('capybara', ['>= 1.1.2', '< 3'])
   s.add_runtime_dependency('cucumber', ['>= 1.3.8', '< 2.1'])
   s.add_runtime_dependency('nokogiri', '~> 1.5')
-  s.add_runtime_dependency('rails', ['>= 3', '< 5'])
+  s.add_runtime_dependency('railties', ['>= 3', '< 5'])
+  s.add_runtime_dependency('mime-types', ['>= 1.16', '< 3'])
 
   # Main development dependencies
   s.add_development_dependency('ammeter', ['>= 0.2.9', '< 2'])
@@ -28,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('factory_girl', '>= 3.2')
   s.add_development_dependency('rake', '>= 0.9.2.2')
   s.add_development_dependency('rspec', '>= 2.2', '<= 3.1')
+  s.add_development_dependency('rails')
 
   # For Documentation:
   s.add_development_dependency('bcat', '>= 0.6.2')


### PR DESCRIPTION
...so that projects that for example don't need ActiveRecord don't automatically have to include it (rails depends on activerecord etc., railties does not).