### PR TITLE
Lock cucumber-aruba gem to `< 0.8`

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # Main development dependencies
   s.add_development_dependency('ammeter', ['>= 0.2.9', '< 2'])
   s.add_development_dependency('appraisal', '>= 0.5.1')
-  s.add_development_dependency('aruba', '>= 0.4.11')
+  s.add_development_dependency('aruba', ['>= 0.4.11', '< 0.8'])
   s.add_development_dependency('builder', ['>= 2.1.2', '< 4'])
   s.add_development_dependency('bundler', '>= 1.3.5')
   s.add_development_dependency('selenium-webdriver', '>= 2.45.0')


### PR DESCRIPTION
The cucumber-aruba gem has had several releases.  Starting from a clean
clone of cucumber-rails, `bundle install` & rake fail since the latest
version of the gem is not compatible.

Fixes issue #299 