### PR TITLE
Expand support to include mime-types 3

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('cucumber', ['>= 1.3.8', '< 3'])
   s.add_runtime_dependency('nokogiri', '~> 1.5')
   s.add_runtime_dependency('railties', ['>= 3', '< 5'])
-  s.add_runtime_dependency('mime-types', ['>= 1.16', '< 3'])
+  s.add_runtime_dependency('mime-types', ['>= 1.16', '< 4'])
 
   # Main development dependencies
   s.add_development_dependency('ammeter', ['>= 0.2.9', '< 1.1.3'])


### PR DESCRIPTION
The tests pass locally. Built on top of #303 because the tests are failing
   for reasons other than mime-types changes.