### PR TITLE
Depend on railties instead of rails

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('factory_girl', '>= 3.2')
   s.add_development_dependency('rake', '>= 0.9.2.2')
   s.add_development_dependency('rspec', '>= 2.2', '<= 3.1')
-  s.add_development_dependency('rails')
+  s.add_development_dependency('railties')
 
   # For Documentation:
   s.add_development_dependency('bcat', '>= 0.6.2')


### PR DESCRIPTION
As far as I can see there is no need to depend on `rails` as a whole, so `railties` only should be enough. That has the benefit that people who are not using e.g. `activerecord` don't get that as an extra dependency when including `cucumber-rails`.