### PR TITLE
locking down mime-types for ruby 1.9.3

### DIFF
--- a/gemfiles/rails_4_0.gemfile
+++ b/gemfiles/rails_4_0.gemfile
@@ -14,5 +14,6 @@ gem "jquery-rails", "~> 2.2.1"
 gem "uglifier", "~> 2.1.0"
 gem "sqlite3", "~> 1.3.7"
 gem "database_cleaner", "~> 1.0.1"
+gem "mime-types", "< 3.1" if RUBY_VERSION < '2.0.0'
 
 gemspec :path => "../"

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -13,5 +13,6 @@ gem "jquery-rails", "~> 2.2.1"
 gem "uglifier", "~> 2.1.0"
 gem "sqlite3", "~> 1.3.7"
 gem "database_cleaner", "~> 1.0.1"
+gem "mime-types", "< 3.1" if RUBY_VERSION < '2.0.0'
 
 gemspec :path => "../"

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -13,5 +13,6 @@ gem "jquery-rails"
 gem "uglifier", "~> 2.1.0"
 gem "sqlite3", "~> 1.3.7"
 gem "database_cleaner", "~> 1.0.1"
+gem "mime-types", "< 3.1" if RUBY_VERSION < '2.0.0'
 
 gemspec :path => "../"


### PR DESCRIPTION
just so 1.9.3 passes on travis