### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 rvm:
   - 2.0.0
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.1.10
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
 
 # whitelist
 branches:
@@ -25,20 +27,36 @@ matrix:
     - rvm: 2.0.0
       gemfile: gemfiles/rails_5_1.gemfile
 
-    - rvm: 2.1.9
+    - rvm: 2.1.10
       gemfile: gemfiles/rails_5_0.gemfile
-    - rvm: 2.1.9
+    - rvm: 2.1.10
       gemfile: gemfiles/rails_5_1.gemfile
 
-    - rvm: 2.2.5
+    - rvm: 2.2.7
       gemfile: gemfiles/rails_4_0.gemfile
-    - rvm: 2.2.5
+    - rvm: 2.2.7
       gemfile: gemfiles/lowest_version_bounds.gemfile
 
-    - rvm: 2.3.1
+    - rvm: 2.3.4
       gemfile: gemfiles/rails_4_0.gemfile
-    - rvm: 2.3.1
+    - rvm: 2.3.4
       gemfile: gemfiles/lowest_version_bounds.gemfile
+
+    - rvm: 2.4.1
+      gemfile: gemfiles/rails_4_0.gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/rails_4_1.gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/lowest_version_bounds.gemfile
+
+    - rvm: ruby-head
+      gemfile: gemfiles/rails_4_0.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails_4_1.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/lowest_version_bounds.gemfile
+  allow_failures:
+    - rvm: ruby-head
 
 before_install: gem update --remote bundler
 


### PR DESCRIPTION
* Updated Rubies to latest version.
* Added ruby-head as allow_failures.
  Because it's good to know new version Ruby's issue as faster before the release.
* Added ruby 2.4.1 as allow_failures to share the test failure.
  => Let me try to test 2.4.1 on Travis.

The motivation is same with https://github.com/cucumber/cucumber-ruby/pull/1087 .
