### PR TITLE
Remove Rack::Test::Methods from the default World.

### DIFF
--- a/lib/cucumber/rails.rb
+++ b/lib/cucumber/rails.rb
@@ -6,6 +6,7 @@ if env_caller
   ENV['RAILS_ROOT'] ||= File.expand_path(env_caller + '/../..')
   require File.expand_path(ENV['RAILS_ROOT'] + '/config/environment')
   require 'cucumber/rails/action_controller'
+  require 'cucumber/rails/configuration'
 
   if defined?(ActiveRecord::Base)
     require 'rails/test_help'

--- a/lib/cucumber/rails/configuration.rb
+++ b/lib/cucumber/rails/configuration.rb
@@ -1,0 +1,26 @@
+module Cucumber
+  module Rails
+    class Configuration
+      attr_writer :use_rack_test_helpers
+
+      def use_rack_test_helpers
+        return @use_rack_test_helpers if defined? @use_rack_test_helpers
+        true
+      end
+    end
+    private_constant :Configuration
+
+    # Sets the specified configuration options, if a block is provided
+    # @return [Configuration] the current configuration object.
+    def self.config
+      yield self.configuration if block_given?
+      self.configuration
+    end
+
+    private
+
+    def self.configuration
+      @config ||= Configuration.new
+    end
+  end
+end

--- a/lib/cucumber/rails/world.rb
+++ b/lib/cucumber/rails/world.rb
@@ -7,7 +7,9 @@ end
 module Cucumber #:nodoc:
   module Rails #:nodoc:
     class World < ActionDispatch::IntegrationTest #:nodoc:
-      include Rack::Test::Methods
+      if Cucumber::Rails.config.use_rack_test_helpers
+        include Rack::Test::Methods
+      end
       include ActiveSupport::Testing::SetupAndTeardown if ActiveSupport::Testing.const_defined?('SetupAndTeardown')
 
       def initialize #:nodoc:


### PR DESCRIPTION
For some reason, the Cucumber `World` instantiated by default by Cucumber-Rails includes the module `Rack::Test::Methods`. This will have the effect of overriding all the default Rails IntegrationTest helpers (`get`, `post`, etc.). Is there a reason for that?

Could we imagine removing this `include` from the default configuration? This seems a right direction, IMHO, for two reasons: 

- It is very easy to add this from the user's Cucumber `env.rb` file, with: `World(Rack::Test::Methods)`.
- It does not seem possible to force the usage of the Rails helpers, instead of the Rack ones (but I can be wrong, I'm quite of a Rails newbie).

Any opinions on that?