### PR TITLE
Restored DatabaseCleaner hook.

### DIFF
--- a/lib/cucumber/rails/hooks/database_cleaner.rb
+++ b/lib/cucumber/rails/hooks/database_cleaner.rb
@@ -1,11 +1,11 @@
 begin
   require 'database_cleaner'
 
-  Before('not @no-database-cleaner') do
+  Before('~@no-database-cleaner') do
     DatabaseCleaner.start if Cucumber::Rails::Database.autorun_database_cleaner
   end
 
-  After('not @no-database-cleaner') do
+  After('~@no-database-cleaner') do
     DatabaseCleaner.clean if Cucumber::Rails::Database.autorun_database_cleaner
   end
 


### PR DESCRIPTION
There are strange issues on CI environment with Ruby 2.0.0 and 2.1.0, so I'm reverting this particular change. This undoes part of https://github.com/cucumber/cucumber-rails/pull/348