### PR TITLE
Reinstate new form of tag negation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
  * Renamed History.md to CHANGELOG.md, added contributing note, and this line in accordance with [cucumber/cucumber #251](https://github.com/cucumber/cucumber/issues/251) ([#345](https://github.com/cucumber/cucumber-rails/pull/345) [jaysonesmith](https://github.com/jaysonesmith))
  * Update .travis.yml with ruby versions ([#341](https://github.com/cucumber/cucumber-rails/pull/341) Jun Aruga)
  * Removed support for Ruby <= 2.1, to keep in line with [cucumber-ruby](https://github.com/cucumber/cucumber-ruby/blob/master/CHANGELOG.md#302-2017-11-11).
+ * Updated syntax to support both new and deprecated forms of tag negation. ([#348](https://github.com/cucumber/cucumber-rails/pull/348) [mirelon](https://github.com/mirelon), [#355](https://github.com/cucumber/cucumber-rails/pull/359) [xtrasimplicity](https://github.com/xtrasimplicity))
  
 ### Fixed
 

--- a/lib/cucumber/rails/hooks/database_cleaner.rb
+++ b/lib/cucumber/rails/hooks/database_cleaner.rb
@@ -1,11 +1,11 @@
 begin
   require 'database_cleaner'
 
-  Before('~@no-database-cleaner') do
+  Before('not @no-database-cleaner') do
     DatabaseCleaner.start if Cucumber::Rails::Database.autorun_database_cleaner
   end
 
-  After('~@no-database-cleaner') do
+  After('not @no-database-cleaner') do
     DatabaseCleaner.clean if Cucumber::Rails::Database.autorun_database_cleaner
   end
 


### PR DESCRIPTION
This was dependent on us removing support for Ruby <= 2.1. Now that that is done (#360), we can add this back and the tests _should_ pass. :+1: 