### PR TITLE
Update for ammeter 1.1.4

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('mime-types', ['>= 1.17', '< 4'])
 
   # Main development dependencies
-  s.add_development_dependency('ammeter', ['>= 1.0.0', '< 1.1.3'])
+  s.add_development_dependency('ammeter', ['>= 1.0.0', '!= 1.1.3'])
   s.add_development_dependency('appraisal', '>= 0.5.1')
   s.add_development_dependency('aruba', '~> 0.14.2')
   s.add_development_dependency('builder', ['>= 3.1.0', '< 4'])

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake', '>= 0.9.2.2')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rails')
+  s.add_development_dependency('sqlite3')
 
   # For Documentation:
   s.add_development_dependency('rdiscount', '>= 2.0.7')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,12 @@
-require 'rubygems'
-
-require 'rails/version'
 require 'rspec/rails/fixture_support'
-# Avoid load order issues in activesupport
-require 'active_support/deprecation'
-# Ensure Rails stuff is present before ammeter needs it
 require 'rails/all'
+
+module CucumberRails
+  class Application < ::Rails::Application
+    self.config.secret_key_base = 'ASecretString' if config.respond_to? :secret_key_base
+  end
+end
+
+require 'rspec/support/spec'
+require 'rspec/rails'
 require 'ammeter/init'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,4 +4,6 @@ require 'rails/version'
 require 'rspec/rails/fixture_support'
 # Avoid load order issues in activesupport
 require 'active_support/deprecation'
+# Ensure Rails stuff is present before ammeter needs it
+require 'rails/all'
 require 'ammeter/init'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'rspec/rails/fixture_support'
 require 'rails/all'
 
+ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+
 module CucumberRails
   class Application < ::Rails::Application
     self.config.secret_key_base = 'ASecretString' if config.respond_to? :secret_key_base


### PR DESCRIPTION
The latest version of ammeter loads capybara/rails, which in turn means Rails.application needs to be present. Somewhere, a connection pool is needed too.