### PR TITLE
Handle rerun files with multiple lines

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -5,7 +5,7 @@ path = if failing_scenarios.empty?
   'features'
 else
   puts "Running failed scenarios"
-  failing_scenarios
+  failing_scenarios.gsub /\s/, ' '
 end
 opts = [
   "--format #{path == 'features' ? 'progress' : 'pretty'}",

--- a/features/rerun_profile.feature
+++ b/features/rerun_profile.feature
@@ -8,12 +8,16 @@ Feature: Rerun profile
     And a file named "rerun.txt" with:
       """
       features/rerun_test.feature:2
+      features/rerun_test.feature:5
       """
     And a file named "features/rerun_test.feature" with:
       """
       Feature: Rerun test
         Scenario: failing before
           Given fixed now
+
+        Scenario: still failing
+          Given broken
 
         Scenario: always passing
           Given passing
@@ -24,14 +28,19 @@ Feature: Rerun profile
         puts "All fixed now"
       end
 
+      Given /broken/ do
+        raise "I'm broken"
+      end
+
       Given /passing/ do
         puts "I've always been passing"
       end
       """
     When I run `bundle exec cucumber -p rerun`
-    Then the feature run should pass with:
+    Then it should fail with:
       """
-      1 scenario (1 passed)
-      1 step (1 passed)
+      2 scenarios (1 failed, 1 passed)
+      2 steps (1 failed, 1 passed)
       """
     And the file "rerun.txt" should not contain "features/rerun_test.feature:2"
+    And the file "rerun.txt" should contain "features/rerun_test.feature:5"

--- a/lib/generators/cucumber/install/templates/config/cucumber.yml.erb
+++ b/lib/generators/cucumber/install/templates/config/cucumber.yml.erb
@@ -1,6 +1,7 @@
 <%%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
-rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
+rerun = rerun.strip.gsub /\s/, ' '
+rerun_opts = rerun.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
 std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
 %>
 default: <%= spork? ? '--drb ' : '' %><%%= std_opts %> features


### PR DESCRIPTION
## Summary

The rerun format generated by cucumber-ruby has changed (see https://github.com/cucumber/cucumber-ruby/issues/1162). This PR updates the cucumber.yml files, both of the project and the generated one, to handle this.

## Details

Instead of spaces, the rerun format now uses newlines. Handle this by replacing all whitespace with spaces.

## Motivation and Context

After failing multiple scenarios, running cucumber again would fail, complaining that cucumber.yml couldn't be read.

## How Has This Been Tested?

I have tested the generated file by updating the relevant feature file with a multi-line rerun file. I have tested the changes to the project file by force-failing two scenarios and checking that could run `bundle exec cucumber` without problems.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
