### PR TITLE
Improve accuracy of Github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
-<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
-<!-- e.g. `tag-expressions: Refactor checks` -->
+<!-- NAMING YOUR PULL REQUEST: Please choose a concise, descriptive name for your pull request. -->
 <!-- This makes it easier to get some context when reading the names of issues -->
 
 <!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->


### PR DESCRIPTION
## Summary
The PR template incorrectly advises contributors to prefix the PR with the name of the sub-project, however cucumber-rails is not part of the cucumber mono-project, as identified in @mvz's review, [here](https://github.com/cucumber/cucumber-rails/pull/367#pullrequestreview-110264630).
```
NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project
 e.g. `tag-expressions: Refactor checks`
```
I've changed this to:
```
NAMING YOUR PULL REQUEST: Please choose a concise, descriptive name for your pull request.
```

## Details
I've added some guidance for how to name a PR.

## Motivation and Context
To make the process of submitting a PR less confusing for contributors.

## How Has This Been Tested?
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cucumber/cucumber-rails/374)
<!-- Reviewable:end -->
