### PR TITLE
[Rebased] Disable display of detailed exceptions

### DIFF
--- a/features/allow_rescue.feature
+++ b/features/allow_rescue.feature
@@ -32,8 +32,7 @@ Feature: Allow Cucumber to rescue exceptions
         visit '/posts'
       end
       Then /^I should see the public error page$/ do
-        expect(page).to have_content "We're sorry, but something went wrong. \
-          If you are the application owner check the logs for more information."
+        expect(page).to have_content "We're sorry, but something went wrong."
       end
       """
     And I run `bundle exec rake db:migrate`

--- a/features/allow_rescue.feature
+++ b/features/allow_rescue.feature
@@ -23,12 +23,17 @@ Feature: Allow Cucumber to rescue exceptions
       Feature: posts
         @allow-rescue
         Scenario: See posts
-          When I look at the posts
+        When I look at the posts
+        Then I should see the public error page
       """
     And I write to "features/step_definitions/posts_steps.rb" with:
       """
       When /^I look at the posts$/ do
         visit '/posts'
+      end
+      Then /^I should see the public error page$/ do
+        expect(page).to have_content "We're sorry, but something went wrong. \
+          If you are the application owner check the logs for more information."
       end
       """
     And I run `bundle exec rake db:migrate`
@@ -36,7 +41,7 @@ Feature: Allow Cucumber to rescue exceptions
     Then the feature run should pass with:
       """
       1 scenario (1 passed)
-      1 step (1 passed)
+      2 steps (2 passed)
       """
 
   Scenario: Don't allow rescue

--- a/lib/cucumber/rails/action_controller.rb
+++ b/lib/cucumber/rails/action_controller.rb
@@ -7,6 +7,7 @@ class ActionDispatch::ShowExceptions
 
   def call(env)
     env['action_dispatch.show_exceptions'] = !!ActionController::Base.allow_rescue
+    env['action_dispatch.show_detailed_exceptions'] = !ActionController::Base.allow_rescue
     __cucumber_orig_call__(env)
   end
 end

--- a/lib/cucumber/rails/action_controller.rb
+++ b/lib/cucumber/rails/action_controller.rb
@@ -7,7 +7,9 @@ class ActionDispatch::ShowExceptions
 
   def call(env)
     env['action_dispatch.show_exceptions'] = !!ActionController::Base.allow_rescue
-    env['action_dispatch.show_detailed_exceptions'] = !ActionController::Base.allow_rescue
+    if Rails.version >= "3.2.1"
+      env['action_dispatch.show_detailed_exceptions'] = !ActionController::Base.allow_rescue
+    end
     __cucumber_orig_call__(env)
   end
 end

--- a/lib/cucumber/rails/action_controller.rb
+++ b/lib/cucumber/rails/action_controller.rb
@@ -7,9 +7,7 @@ class ActionDispatch::ShowExceptions
 
   def call(env)
     env['action_dispatch.show_exceptions'] = !!ActionController::Base.allow_rescue
-    if Rails.version >= "3.2.1"
-      env['action_dispatch.show_detailed_exceptions'] = !ActionController::Base.allow_rescue
-    end
+    env['action_dispatch.show_detailed_exceptions'] = !ActionController::Base.allow_rescue
     __cucumber_orig_call__(env)
   end
 end


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please choose a concise, descriptive name for your pull request. -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
<em>This is the same as [#296 (PR)](https://github.com/cucumber/cucumber-rails/pull/296), but has been rebased onto the latest changes to master. The following summary is copied from the other PR.</em>

`@allow-rescue` permits rescuing exceptions by setting `action_dispatch.show_exceptions` to true in the env hash. However, this will render the detailed error page and not the public error page you'd encounter in production.

Given that the feature enables testing of error pages, and seems to be intended to mirror production behaviour as per the comment on https://github.com/cucumber/cucumber-rails/blob/master/lib/generators/cucumber/install/templates/support/_rails_each_run.rb.erb#L6-L14, this PR sets `action_dispatch.show_detailed_exceptions` to false, thus enabling the public error page to be rendered.
## How Has This Been Tested?
The `allow_rescue` feature has been extended to verify the content of the error page.
<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cucumber/cucumber-rails/387)
<!-- Reviewable:end -->
