### PR TITLE
Deprecate safe_level of ERB.new in Ruby 2.6

### DIFF
--- a/lib/generators/cucumber/install/install_generator.rb
+++ b/lib/generators/cucumber/install/install_generator.rb
@@ -60,7 +60,11 @@ module Cucumber
 
     def embed_template(source, indent = '')
       template = File.join(self.class.source_root, source)
-      ERB.new(IO.read(template), nil, '-').result(binding).gsub(/^/, indent)
+      if RUBY_VERSION >= '2.6'
+        ERB.new(IO.read(template), trim_mode: nil, eoutvar: '-').result(binding).gsub(/^/, indent)
+      else
+        ERB.new(IO.read(template), nil, '-').result(binding).gsub(/^/, indent)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087/NEWS#stdlib-updates-outstanding-ones-only

## Motivation and Context

Related PR: https://github.com/cucumber/cucumber-ruby/pull/1301

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
