### PR TITLE
Exclude Rails 4.2 + ruby-head (2.6) build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
+  exclude:
+    - rvm: ruby-head
+      gemfile: gemfiles/rails_4_2.gemfile
 
 before_install:
   - gem update --system


### PR DESCRIPTION
## Summary

Exclude Rails 4.2 + ruby-head (2.6) build matrix from Travis CI.

## Details

This PR excludes the following error matrix from Travis CI.

```console
NoMethodError:
  undefined method `new' for BigDecimal:Class
# /home/travis/.rvm/gems/ruby-head/gems/activesupport-4.2.11/lib/active_support/core_ext/object/duplicable.rb:111:in `<class:BigDecimal>'
```

https://travis-ci.org/cucumber/cucumber-rails/jobs/462430088#L1569-L1594

## Motivation and Context

Rails 4.2 is using `BigDecimal.new`. However `BigDecimal.new` was removed from Ruby 2.6.
https://github.com/ruby/ruby/commit/2810c12a99fed7297d558d8b1aaaf755eb8b8a2d#diff-64cf76d72ee12a82d3093efe6c2f83f7

```console
% ruby -rbigdecimal -ve 'BigDecimal.new(5.0)'
ruby 2.6.0dev (2018-12-10 trunk 66302) [x86_64-darwin17]
/Users/koic/.rbenv/versions/2.6.0-dev/lib/ruby/site_ruby/2.6.0/rubygems/version.rb:216:
warning: deprecated Object#=~ is called on Integer; it always returns
nil
Traceback (most recent call last):
-e:1:in `<main>': undefined method `new' for BigDecimal:Class (NoMethodError)
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
