### PR TITLE
Fix an error for ruby-head (2.6) CI matrix

### DIFF
--- a/lib/generators/cucumber/install/install_generator.rb
+++ b/lib/generators/cucumber/install/install_generator.rb
@@ -61,7 +61,7 @@ module Cucumber
     def embed_template(source, indent = '')
       template = File.join(self.class.source_root, source)
       if RUBY_VERSION >= '2.6'
-        ERB.new(IO.read(template), trim_mode: nil, eoutvar: '-').result(binding).gsub(/^/, indent)
+        ERB.new(IO.read(template), trim_mode: '-').result(binding).gsub(/^/, indent)
       else
         ERB.new(IO.read(template), nil, '-').result(binding).gsub(/^/, indent)
       end


### PR DESCRIPTION
## Summary

There was a mistake in the keyword argument of `ERB.new` for Ruby 2.6.0-dev.

## Details

This PR fixes the following errors for Ruby 2.6.0-dev CI matrix.

```console
  1) Cucumber::InstallGenerator no arguments config/cucumber.yml
     Failure/Error: ERB.new(IO.read(template), trim_mode: nil, eoutvar:  '-').result(binding).gsub(/^/, indent)

     SyntaxError:
       (erb):1: syntax error, unexpected '='
       - = +''; -.<< "require 'cucumber...
         ^
       (erb):1: syntax error, unexpected '.'
       - = +''; -.<< "require 'cucumber/rails'\...
                 ^
       (erb):2: syntax error, unexpected end-of-input

(snip)

Finished in 0.04433 seconds (files took 1.34 seconds to load)
16 examples, 11 failures
```

https://travis-ci.org/cucumber/cucumber-rails/jobs/465896307

## Motivation and Context

The above error is a regression by #399 💦 This PR handles `trim_mode` correctly.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
