### PR TITLE
Revert "Exclude Rails 4.2 + ruby-head (2.6) build"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
-  exclude:
-    - rvm: ruby-head
-      gemfile: gemfiles/rails_4_2.gemfile
 
 before_install:
   - gem update --remote bundler


### PR DESCRIPTION
## Summary

This reverts commit e4b7e5fd11f042c5fc532b9798a0ae5faf130e61.

## Details

This PR restores Rails 4.2 + ruby-head (2.6) build.

`BigDecimal.new` has been replaced with deprecation rather than deletion.

```console
% ruby -rbigdecimal -ve 'BigDecimal.new(42)'
ruby 2.6.0dev (2018-12-24 trunk 66524) [x86_64-darwin17]
-e:1: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```

## Motivation and Context

Follow up of https://github.com/cucumber/cucumber-rails/pull/400#issuecomment-447177153.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
