### PR TITLE
Fix a build error for Ruby 2.2 matrix on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ matrix:
       gemfile: gemfiles/rails_4_2.gemfile
 
 before_install:
-  - gem update --system
   - gem update --remote bundler
   - bin/install_geckodriver.sh
 


### PR DESCRIPTION
## Summary

Fix a build error for Ruby 2.2 matrix on Travis CI.

## Details

This PR fixes the following build error.

```console
$ gem update --system
Updating rubygems-update
Fetching: rubygems-update-3.0.1.gem (100%)
ERROR:  Error installing rubygems-update:
        rubygems-update requires Ruby version >= 2.3.0.
ERROR:  While executing gem ... (NoMethodError)
    undefined method `version' for nil:NilClass
The command "gem update --system" failed and exited with 1 during .
```

https://travis-ci.org/cucumber/cucumber-rails/jobs/471780986#L480-L487

## Motivation and Context

RubyGems 3.0.1 requires Ruby 2.3.0 or higher.
https://github.com/rubygems/rubygems/blob/v3.0.1/rubygems-update.gemspec#L32

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
