### PR TITLE
Ensure working version of sqlite3 is used in scenarios

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,17 +1,25 @@
 appraise "rails_4_2" do
   gem "railties", "~> 4.2.1"
+  gem "i18n", "< 1.6.0", platform: :mri_22
+  gem "capybara", "< 3.16.0", platform: [:mri_23, :mri_22]
 end
 
 appraise "rails_5_0" do
   gem "railties", "~> 5.0.0"
+  gem "i18n", "< 1.6.0", platform: :mri_22
+  gem "capybara", "< 3.16.0", platform: [:mri_23, :mri_22]
 end
 
 appraise "rails_5_1" do
   gem "railties", "~> 5.1.0"
+  gem "i18n", "< 1.6.0", platform: :mri_22
+  gem "capybara", "< 3.16.0", platform: [:mri_23, :mri_22]
 end
 
 appraise "rails_5_2" do
   gem "railties", "~> 5.2"
+  gem "i18n", "< 1.6.0", platform: :mri_22
+  gem "capybara", "< 3.16.0", platform: [:mri_23, :mri_22]
 end
 
 appraise "rails_6_0" do

--- a/features/step_definitions/cucumber_rails_steps.rb
+++ b/features/step_definitions/cucumber_rails_steps.rb
@@ -18,7 +18,11 @@ module CucumberRailsHelper
     end
 
     gem 'sqlite3', '~> 1.3.13'
-    gem 'capybara', group: :test
+    if RUBY_VERSION < '2.4.0'
+      gem 'capybara', '< 3.16.0', group: :test
+    else
+      gem 'capybara', group: :test
+    end
     gem 'selenium-webdriver', '~> 3.11', group: :test
 
     gem 'rspec-expectations', '~> 3.7', group: :test

--- a/features/step_definitions/cucumber_rails_steps.rb
+++ b/features/step_definitions/cucumber_rails_steps.rb
@@ -17,6 +17,7 @@ module CucumberRailsHelper
       gem 'cucumber-rails' , group: :test, require: false, path: "#{File.expand_path('.')}"
     end
 
+    gem 'sqlite3', '~> 1.3.13'
     gem 'capybara', group: :test
     gem 'selenium-webdriver', '~> 3.11', group: :test
 

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -3,5 +3,7 @@
 source "https://rubygems.org"
 
 gem "railties", "~> 4.2.1"
+gem "i18n", "< 1.6.0", platform: :mri_22
+gem "capybara", "< 3.16.0", platform: [:mri_23, :mri_22]
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -3,5 +3,7 @@
 source "https://rubygems.org"
 
 gem "railties", "~> 5.0.0"
+gem "i18n", "< 1.6.0", platform: :mri_22
+gem "capybara", "< 3.16.0", platform: [:mri_23, :mri_22]
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -3,5 +3,7 @@
 source "https://rubygems.org"
 
 gem "railties", "~> 5.1.0"
+gem "i18n", "< 1.6.0", platform: :mri_22
+gem "capybara", "< 3.16.0", platform: [:mri_23, :mri_22]
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -3,5 +3,7 @@
 source "https://rubygems.org"
 
 gem "railties", "~> 5.2"
+gem "i18n", "< 1.6.0", platform: :mri_22
+gem "capybara", "< 3.16.0", platform: [:mri_23, :mri_22]
 
 gemspec path: "../"


### PR DESCRIPTION
## Summary

Force the use of sqlite3 version 1.3.x when running scenarios that test installing Rails and cucumber-rails. Since these scenarios break out of the bundle created by the gemspec, they might otherwise pick up later versions of sqlite3 by accident.

This is currently causing build failures with Rails 4.2 and 5.0, since they have no released version with support for sqlite3 1.4.

## Details

Add a gem line for sqlite3 to the relevant cucumber step.

## Motivation and Context

The Travis build is currently failing.

## How Has This Been Tested?

Running the full test suite for Rails 5.2. Travis will test the other versions.

## Types of changes

- Bug fix (non-breaking change which fixes an issue).