### PR TITLE
Use newer aruba methods instead of deprecated ones

### DIFF
--- a/features/step_definitions/cucumber_rails_steps.rb
+++ b/features/step_definitions/cucumber_rails_steps.rb
@@ -1,8 +1,9 @@
 module CucumberRailsHelper
   def rails_new(options = {})
     options[:name] ||= 'test_app'
-    command = run "bundle exec rails new #{options[:name]} --skip-bundle --skip-test-unit --skip-spring #{options[:args]}"
-    expect(command).to have_output /README/
+    command_result =
+      run_command "bundle exec rails new #{options[:name]} --skip-bundle --skip-test-unit --skip-spring #{options[:args]}"
+    expect(command_result).to have_output /README/
     expect(last_command_started).to be_successfully_executed
     cd options[:name]
     delete_environment_variable 'RUBYOPT'
@@ -28,11 +29,11 @@ module CucumberRailsHelper
     gem 'rspec-expectations', '~> 3.7', group: :test
     gem 'database_cleaner', '>= 1.1', group: :test unless options.include?(:no_database_cleaner)
     gem 'factory_bot', '>= 3.2', group: :test unless options.include?(:no_factory_bot)
-    run_simple 'bundle install'
+    run_command_and_stop 'bundle install'
 
-    run_simple 'bundle exec rails webpacker:install' if rails6?
+    run_command_and_stop 'bundle exec rails webpacker:install' if rails6?
 
-    run_simple 'bundle exec rails generate cucumber:install'
+    run_command_and_stop 'bundle exec rails generate cucumber:install'
   end
 
   def gem(name, *args)
@@ -111,8 +112,8 @@ Given /^I have created a new Rails app "(.*?)" with no database and installed cu
 end
 
 Given /^I have a "([^"]*)" ActiveRecord model object$/ do |name|
-  run_simple("bundle exec rails g model #{name}")
-  run_simple('bundle exec rake db:migrate RAILS_ENV=test')
+  run_command_and_stop "bundle exec rails g model #{name}"
+  run_command_and_stop 'bundle exec rake db:migrate RAILS_ENV=test'
 end
 
 Given 'I force selenium to run Firefox in headless mode' do
@@ -138,7 +139,7 @@ Given 'I force selenium to run Firefox in headless mode' do
 end
 
 When 'I run the cukes' do
-  run_simple('bundle exec cucumber')
+  run_command_and_stop 'bundle exec cucumber'
 end
 
 # Copied from Aruba


### PR DESCRIPTION
## Summary

Removes clunk from stdout from using deprecated aruba methods

## Details

Same as above

## Motivation and Context

Remove stdout pollution so it's easier to see terminal output

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
