### PR TITLE
Remove Aruba reporting monkey-patch

### DIFF
--- a/features/step_definitions/cucumber_rails_steps.rb
+++ b/features/step_definitions/cucumber_rails_steps.rb
@@ -2,14 +2,12 @@ Given('I have created a new Rails app and installed cucumber-rails, accidentally
   rails_new
   install_cucumber_rails :not_in_test_group
   create_web_steps
-  prepare_aruba_report
 end
 
 Given('I have created a new Rails app and installed cucumber-rails') do
   rails_new
   install_cucumber_rails
   create_web_steps
-  prepare_aruba_report
 end
 
 Given('I have created a new Rails app with no database and installed cucumber-rails') do

--- a/features/support/cucumber_rails_helper.rb
+++ b/features/support/cucumber_rails_helper.rb
@@ -59,13 +59,6 @@ module CucumberRailsHelper
     end
   end
 
-  def prepare_aruba_report
-    return unless ENV['ARUBA_REPORT_DIR']
-
-    @aruba_report_start = Time.new
-    sleep(1)
-  end
-
   def fixture(path)
     File.expand_path(File.dirname(__FILE__) + "./../support/fixtures/#{path}")
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,29 +4,6 @@ require 'bundler/setup'
 require 'rspec/expectations'
 require 'aruba/cucumber'
 
-if ENV['ARUBA_REPORT_DIR']
-  # Override reporting behaviour so we don't document all files, only the ones
-  # that have been created after @aruba_report_start (a Time object). This is
-  # given a value after the Rails app is generated (see cucumber_rails_steps.rb)
-  module Aruba
-    module Reporting
-      def children(dir)
-        children = Dir["#{dir}/*"].sort
-
-        # include
-        children = children.select do |child|
-          File.directory?(child) || (@aruba_report_start && File.stat(child).mtime > @aruba_report_start)
-        end
-
-        # exclude
-        children.reject do |child|
-          child =~ /Gemfile/ || child =~ /\.log$/
-        end
-      end
-    end
-  end
-end
-
 After do |scenario|
   if scenario.failed?
     puts last_command_stopped.stdout


### PR DESCRIPTION
## Summary

Remove Aruba reporting monkey-patch

## Details

Removes code from Cucumber-Rails that tests for ARUBA_REPORT_DIR and overrides Aruba's reporting code. Also removes `prepare_aruba_report` calls from the step definitions.

## Motivation and Context

Aruba reporting is deprecated and broken with Cucumber 2 and up, and Cucumber-Rails requires Cucumber 3. Therefore, it is safe to say that no-one is using this feature for running Cucumber-Rails' test suite.

## How Has This Been Tested?

I ran `ARUBA_REPORT_DIR=tmp bundle exec rake` without this change and it fails, even after adding `bcat` as a dependency, with the message:

```
undefined method `line' for #<Cucumber::Core::Test::Case: features/allow_rescue.feature:20> (NoMethodError)
```

## Types of changes

Basically a cleanup. Removes something that was broken.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
