### PR TITLE
Avoid using bootsnap on CI for stable builds

### DIFF
--- a/features/support/cucumber_rails_helper.rb
+++ b/features/support/cucumber_rails_helper.rb
@@ -2,7 +2,7 @@ module CucumberRailsHelper
   def rails_new(options = {})
     options[:name] ||= 'test_app'
     command_result =
-      run_command "bundle exec rails new #{options[:name]} --skip-bundle --skip-test-unit --skip-spring #{options[:args]}"
+      run_command "bundle exec rails new #{options[:name]} --skip-bundle --skip-test-unit --skip-spring --skip-bootsnap #{options[:args]}"
     expect(command_result).to have_output /README/
     expect(last_command_started).to be_successfully_executed
     cd options[:name]


### PR DESCRIPTION
Here's a quick attempt to fix the CI failure problem on ruby 2.7.0, aka #426
