### PR TITLE
Update CHANGELOG to include removal of Ruby 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,19 @@
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
-## [master](https://github.com/cucumber/cucumber-rails/compare/v1.6.0...master) (Not yet released)
-There are currently no unreleased changes.
+## [master](https://github.com/cucumber/cucumber-rails/compare/v1.7.0...master) (Not yet released)
 
+### Changed
+
+ * Drop Ruby 2.2 support (target 2.3 and up) ([#424](https://github.com/cucumber/cucumber-rails/pull/424) [mvz])
+ 
 ## [v1.7.0](https://github.com/cucumber/cucumber-rails/compare/v1.6.0...v1.7.0) (2019-04-17)
 
 ### Changed
 
- * Drop rails `4.0` / `4.1` support ([#392](https://github.com/cucumber/cucumber-rails/pull/392) [deivid-rodriguez](https://github.com/deivid-rodriguez))
- * Allow Ruby `2.6` users to `ERB.new` ([#399](https://github.com/cucumber/cucumber-rails/pull/399) [koic](https://github.com/koic))
- * Allow Rails to be used in the `6.x` series (Currently as of release only beta1 is supported) ([#405](https://github.com/cucumber/cucumber-rails/pull/405) [kotovalexarian](https://github.com/kotovalexarian))
- * Update CI to test most relevant Rubies ([#411](https://github.com/cucumber/cucumber-rails/pull/411) [olleolleolle](https://github.com/olleolleolle))
+ * Drop rails `4.0` / `4.1` support ([#392](https://github.com/cucumber/cucumber-rails/pull/392) [deivid-rodriguez])
+ * Allow Ruby `2.6` users to `ERB.new` ([#399](https://github.com/cucumber/cucumber-rails/pull/399) [koic])
+ * Allow Rails to be used in the `6.x` series (Currently as of release only beta1 is supported) ([#405](https://github.com/cucumber/cucumber-rails/pull/405) [kotovalexarian])
+ * Update CI to test most relevant Rubies ([#411](https://github.com/cucumber/cucumber-rails/pull/411) [olleolleolle])
 
 ### Fixed
 
@@ -492,3 +495,10 @@ and to celebrate that cucumber-rails now supports Capybara as an alternative to 
 * Webrat step "Then I should be on" should use request_uri instead of path for missing query string parameters (ZhangJinzhu)
 * Added MIME type parameter to attach file step definition (Felix Flores)
 * Added check when including ActiveSupport::Testing::SetupAndTeardown for older Rails versions (Jeremy Durham)
+
+
+[deivid-rodriguez]: https://github.com/deivid-rodriguez
+[koic]: https://github.com/koic
+[kotovalexarian]: https://github.com/kotovalexarian
+[mvz]: https://github.com/mvz
+[olleolleolle]: https://github.com/olleolleolle


### PR DESCRIPTION
## Summary

This amends the CHANGELOG document to include the latest work on removing Ruby 2.2 support.

See #425 

## Details

- Also: Fix compare link in title of "master release".
- Also: Format usernames using reference-style links. What do you think about that? Should I complete it throughout the document? We _are_ hand-writing this, so it ought to simplify things.

## Motivation and Context

I hope we soon get to release a new version.

## How Has This Been Tested?

I previewed.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
