### PR TITLE
Fix Rakefile error handling

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ namespace :test do
   desc 'Run tests against specified gemfile, e.g. rake test:gemfile[rails_3_0]'
   task :gemfile, :name do |_task, args|
     unless args.name && Pathname.new("gemfiles/#{args.name}.gemfile").exist?
-      raise ArgumentError "You must provide the name of an existing Appraisal gemfile,
+      raise ArgumentError, "You must provide the name of an existing Appraisal gemfile,
         e.g. 'rake test:gemfile[rails_4_2]'"
     end
 


### PR DESCRIPTION
## Summary

Fixes a small bug that makes mis-typing the argument for `rake test:gemfile` raise the wrong error.

## Details

Adds a comma so `ArgumentError` is not interpreted as a (non-existent) method.

## Motivation and Context

Makes the error message actually useful.

## How Has This Been Tested?

I tested it with an incorrect invocation of this rake task.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
