### PR TITLE
Update RuboCop and RuboCop-RSpec, and fix new offenses

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3.6')
   s.add_development_dependency('rubocop', '~> 0.74.0')
   s.add_development_dependency('rubocop-performance', '~> 1.4.0')
-  s.add_development_dependency('rubocop-rspec', '~> 1.33.0')
+  s.add_development_dependency('rubocop-rspec', '~> 1.35.0')
   s.add_development_dependency('sqlite3', '~> 1.3')
 
   # For Documentation:

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rails', ['>= 4.2', '< 7'])
   s.add_development_dependency('rake', '>= 12.0')
   s.add_development_dependency('rspec', '~> 3.6')
-  s.add_development_dependency('rubocop', '~> 0.72.0')
+  s.add_development_dependency('rubocop', '~> 0.74.0')
   s.add_development_dependency('rubocop-performance', '~> 1.4.0')
   s.add_development_dependency('rubocop-rspec', '~> 1.33.0')
   s.add_development_dependency('sqlite3', '~> 1.3')

--- a/spec/cucumber/rails/database_spec.rb
+++ b/spec/cucumber/rails/database_spec.rb
@@ -24,32 +24,36 @@ describe Cucumber::Rails::Database do
   end
 
   context 'when using a custom strategy' do
-    let(:strategy_type) { ValidStrategy }
+    let(:strategy_type) { valid_strategy }
 
-    class ValidStrategy
-      def before_js
-        # Anything
-      end
+    let(:valid_strategy) do
+      Class.new do
+        def before_js
+          # Anything
+        end
 
-      def before_non_js
-        # Likewise
+        def before_non_js
+          # Likewise
+        end
       end
     end
 
-    class InvalidStrategy; end
+    let(:invalid_strategy) do
+      Class.new
+    end
 
     it 'raises an error if the strategy does not have a valid interface' do
-      expect { described_class.javascript_strategy = InvalidStrategy }
+      expect { described_class.javascript_strategy = invalid_strategy }
         .to raise_error(ArgumentError)
     end
 
     it 'accepts the strategy if it has a valid interface' do
-      expect { described_class.javascript_strategy = ValidStrategy }
+      expect { described_class.javascript_strategy = valid_strategy }
         .not_to raise_error
     end
 
     it 'forwards events to the strategy' do
-      described_class.javascript_strategy = ValidStrategy
+      described_class.javascript_strategy = valid_strategy
 
       expect(strategy).to receive(:before_non_js)
       described_class.before_non_js

--- a/spec/cucumber/rails/database_spec.rb
+++ b/spec/cucumber/rails/database_spec.rb
@@ -23,7 +23,7 @@ describe Cucumber::Rails::Database do
       .to raise_error(Cucumber::Rails::Database::InvalidStrategy)
   end
 
-  context 'using a custom strategy' do
+  context 'when using a custom strategy' do
     let(:strategy_type) { ValidStrategy }
 
     class ValidStrategy


### PR DESCRIPTION
## Summary

Updates the `rubocop` and `rubocop-rspec` dependencies to their latest version, and fixes new detected offenses.

## Details

* Update `rubocop` to `0.74.0`
* Update `rubocop-rspec` to `1.35.0`
* Update wording of `context` block so it includes `with`
* Restructure a spec to avoid creating new constants inside that spec

## Motivation and Context

Keeps things up-to-date.

## How Has This Been Tested?

I ran rubocop and the specs again after this change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
