### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |s|
     'changelog_uri' => "https://github.com/cucumber/cucumber-rails/blob/v#{s.version}/CHANGELOG.md",
     'documentation_uri' => 'https://cucumber.io/docs',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/cukes',
-    'source_code_uri' => "https://github.com/cucumber/cucumber-rails/tree/v#{s.version}",
-    'wiki_uri' => 'https://github.com/cucumber/cucumber-rails/wiki'
+    'source_code_uri' => "https://github.com/cucumber/cucumber-rails/tree/v#{s.version}"
   }
 
   s.add_runtime_dependency('capybara', ['>= 2.12', '< 4'])

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -9,9 +9,18 @@ Gem::Specification.new do |s|
   s.description = 'Cucumber Generator and Runtime for Rails'
   s.summary     = "#{s.name}-#{s.version}"
   s.email       = 'cukes@googlegroups.com'
-  s.homepage    = 'http://cukes.info'
+  s.homepage    = 'https://cucumber.io'
 
   s.license = 'MIT'
+
+  s.metadata = {
+    'bug_tracker_uri' => 'https://github.com/cucumber/cucumber-rails/issues',
+    'changelog_uri' => "https://github.com/cucumber/cucumber-rails/blob/v#{s.version}/CHANGELOG.md",
+    'documentation_uri' => 'https://cucumber.io/docs',
+    'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/cukes',
+    'source_code_uri' => "https://github.com/cucumber/cucumber-rails/tree/v#{s.version}",
+    'wiki_uri' => 'https://github.com/cucumber/cucumber-rails/wiki'
+  }
 
   s.add_runtime_dependency('capybara', ['>= 2.12', '< 4'])
   s.add_runtime_dependency('cucumber', ['>= 3.0.2', '< 4'])


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `mailing_list_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/cucumber-rails), via the Rubygems API, and the `gem` and `bundle` command-line tools with the next release.

Also update the homepage URL.

