### PR TITLE
Update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,7 @@ Style/NumericLiteralPrefix:
 
 ## Cucumber Repo styles (Across implementations) ##
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 200
   IgnoredPatterns:
     - '^Given'

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bundler', '>= 1.17')
   s.add_development_dependency('rake', '>= 12.0')
   s.add_development_dependency('rspec', '~> 3.6')
-  s.add_development_dependency('rubocop', '~> 0.76.0')
+  s.add_development_dependency('rubocop', '~> 0.78.0')
   s.add_development_dependency('rubocop-performance', '~> 1.5.0')
   s.add_development_dependency('rubocop-rspec', '~> 1.37.0')
   s.add_development_dependency('sqlite3', '~> 1.3')


### PR DESCRIPTION
## Summary

Bump rubocop dependency and update config file with new cop namespace.

## Details

Rubocop 0.78.0 changed the namespace for the LineLength cop.

## Motivation and Context

Keeps things up-to-date.

## How Has This Been Tested?

I ran rubocop.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
