### PR TITLE
Resolve NameError occurring in TravisCI

### DIFF
--- a/lib/cucumber/rails/world.rb
+++ b/lib/cucumber/rails/world.rb
@@ -20,7 +20,7 @@ end
 
 module Cucumber
   module Rails
-    class World < ActionDispatch::IntegrationTest
+    class World < ::ActionDispatch::IntegrationTest
       include Rack::Test::Methods if Cucumber::Rails.include_rack_test_helpers?
       include ActiveSupport::Testing::SetupAndTeardown if ActiveSupport::Testing.const_defined?('SetupAndTeardown')
 


### PR DESCRIPTION
The build is failing with multiple occurrences of the following error:
`uninitialized constant Cucumber::Rails::ActionDispatch::IntegrationTest
(NameError)`

Example:
https://travis-ci.org/cucumber/cucumber-rails/jobs/650040930

I have also encountered this error when pointing a project at a local build
of `cucumber-rails` at `master`.

As `IntegrationTest` does not live in the
`Cucumber::Rails::ActionDispatch` namespace, this commit makes the
change to read `ActionDispatch::IntegrationTest` from the global
namespace.