### PR TITLE
Skip cache_classes warning when using Spring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Fixed
 
- * 
+ * Avoid printing a warning about `config.cache_classes` being set to `false` when
+   Spring is used ([#462](https://github.com/cucumber/cucumber-rails/pull/462) [janko])
 
-## [v2.0.0](https://github.com/cucumber/cucumber-rails/compare/v1.8.0...v2.0.0) (2019-09-013)
+## [v2.0.0](https://github.com/cucumber/cucumber-rails/compare/v1.8.0...v2.0.0) (2019-09-13)
 
 ### New Features
 

--- a/lib/cucumber/rails.rb
+++ b/lib/cucumber/rails.rb
@@ -15,7 +15,7 @@ if called_from_env_rb
 
   unless Rails.application.config.cache_classes || defined?(Spring)
     warn "WARNING: You have set Rails' config.cache_classes to false
-    or are using Spring. This is known to cause problems
+    (Spring needs cache_classes set to false). This is known to cause problems
     with database transactions. Set config.cache_classes to true if you want to use transactions."
   end
 

--- a/lib/cucumber/rails.rb
+++ b/lib/cucumber/rails.rb
@@ -13,7 +13,7 @@ if called_from_env_rb
   require 'cucumber/rails/action_dispatch'
   require 'rails/test_help'
 
-  unless Rails.application.config.cache_classes
+  unless Rails.application.config.cache_classes || defined?(Spring)
     warn "WARNING: You have set Rails' config.cache_classes to false
     (most likely in config/environments/cucumber.rb). This setting is known to cause problems
     with database transactions. Set config.cache_classes to true if you want to use transactions."

--- a/lib/cucumber/rails.rb
+++ b/lib/cucumber/rails.rb
@@ -15,7 +15,7 @@ if called_from_env_rb
 
   unless Rails.application.config.cache_classes || defined?(Spring)
     warn "WARNING: You have set Rails' config.cache_classes to false
-    (most likely in config/environments/cucumber.rb). This setting is known to cause problems
+    or are using Spring. This is known to cause problems
     with database transactions. Set config.cache_classes to true if you want to use transactions."
   end
 


### PR DESCRIPTION
## Summary

Avoid printing out warning when `cache_classes` needs to be `false`.

## Details

The `cache_classes` setting needs to be `false` when Spring is used. In this
case cucumber-rails doesn't have to print out the warning.

## Motivation and Context

See https://github.com/rails/spring/issues/598#issuecomment-528121218.

## How Has This Been Tested?

I'm not sure whether this change requires tests, it probably doesn't make sense
to pull in Spring just for that.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
