### PR TITLE
Fix deprecation

### DIFF
--- a/features/choose_javascript_database_strategy.feature
+++ b/features/choose_javascript_database_strategy.feature
@@ -37,7 +37,7 @@ Feature: Choose javascript database strategy
       end
 
       Then('the DatabaseCleaner strategy should be {word}') do |strategy_name|
-        expect(DatabaseCleaner.connections.first.strategy.to_s).to match(/#{strategy_name}/i)
+        expect(DatabaseCleaner.cleaners.values.first.strategy.to_s).to match(/#{strategy_name}/i)
       end
       """
 

--- a/features/support/cucumber_rails_helper.rb
+++ b/features/support/cucumber_rails_helper.rb
@@ -12,7 +12,7 @@ module CucumberRailsHelper
     add_gem 'capybara', group: :test
     add_gem 'selenium-webdriver', '~> 3.11', group: :test
     add_gem 'rspec-expectations', '~> 3.7', group: :test
-    add_gem 'database_cleaner', '>= 1.1', group: :test unless options.include?(:no_database_cleaner)
+    add_gem 'database_cleaner', '>= 1.8.0', group: :test unless options.include?(:no_database_cleaner)
     add_gem 'factory_bot', '>= 3.2', group: :test unless options.include?(:no_factory_bot)
 
     run_command_and_stop 'bundle install'

--- a/lib/cucumber/rails/database.rb
+++ b/lib/cucumber/rails/database.rb
@@ -76,7 +76,11 @@ module Cucumber
         end
 
         def before_js(strategy)
-          @original_strategy = DatabaseCleaner.connections.first.strategy # that feels like a nasty hack
+          @original_strategy = if Gem::Version.new(DatabaseCleaner::VERSION) >= Gem::Version.new('1.8.0.beta')
+                                 DatabaseCleaner.cleaners.values.first.strategy # that feels like a nasty hack
+                               else
+                                 DatabaseCleaner.connections.first.strategy # that feels like a nasty hack
+                               end
           DatabaseCleaner.strategy = strategy, @options
         end
 


### PR DESCRIPTION
## Summary

Trying to fix a deprecation message coming from the `database_cleaner` gem.

Fixes #459.

## Details

My changes consist of:

* For the usage inside "lib", make sure to use the proper API according to its availabilty. That means using `DatabaseCleaner.cleaners [if available](https://github.com/DatabaseCleaner/database_cleaner/commit/d226e25312bdd2f2e1705f832b3e39612e3eee8e).

* For the usages inside our own features, bump the `database_cleaner` in use to a high enough version, and switch to `DatabaseCleaner.cleaners` unconditionally.

## Motivation and Context

Remove deprecation messages from test suites.

## How Has This Been Tested?

Not yet, I'll start with CI, then test it on my project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
