### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 
-dist: xenial
+dist: bionic
 
 rvm:
   - 2.3

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Aruba.configure do |config|
-  config.exit_timeout = 120
+  config.exit_timeout = 360
 end

--- a/features/support/cucumber_rails_helper.rb
+++ b/features/support/cucumber_rails_helper.rb
@@ -37,7 +37,9 @@ module CucumberRailsHelper
 
   def run_rails_new_command(options)
     options[:name] ||= 'test_app'
-    run_command "bundle exec rails new #{options[:name]} --skip-bundle --skip-test-unit --skip-spring --skip-bootsnap #{options[:args]}"
+    flags = '--skip-bundle --skip-test-unit --skip-spring --skip-bootsnap'
+    flags += ' --skip-webpack-install' if rails6?
+    run_command "bundle exec rails new #{options[:name]} #{flags} #{options[:args]}"
   end
 
   def validate_rails_new_success(result)


### PR DESCRIPTION
## Summary

Just trying to get the CI green. This PR closes #461.

## Details

CI is broken on Rails 6. This PR introduces a number of changes to get CI green again:

* Delay webpacker installation to a point where `cucumber-rails` is properly setup in the dummy application `Gemfile`. Otherwise we get warnings like this:

>WARNING: Cucumber-rails required outside of env.rb.  The rest of loading is being deferred
until env.rb is called. To avoid this warning, move 'gem 'cucumber-rails', require: false'under only group :test in your Gemfile. If already in the :test group, be sure you arespecifying 'require: false'.

and also a hard error about `rails` generator not finding the `webpacker:install` task. Honestly I'm not fully sure why it's happening, but we're running `webpacker:install` later on, so it's unnecessary to include `webpacker` on the initial dummy application generation.

* Increase aruba's commands timeout, since `sassc` compilation is very slow, and it comes by default on Rails 6.

* Bump the nodejs version being used to a version compatible with webpacker. Otherwise we get errors like this:

> Webpacker requires Node.js >= 8.16.0 and you are using 8.12.0
> Please upgrade Node.js https://nodejs.org/en/download/

## Motivation and Context

To have a green CI.

## How Has This Been Tested?

In CI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
