### PR TITLE
Update rubocop

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -34,9 +34,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bundler', '>= 1.17')
   s.add_development_dependency('rake', '>= 12.0')
   s.add_development_dependency('rspec', '~> 3.6')
-  s.add_development_dependency('rubocop', '~> 0.78.0')
+  s.add_development_dependency('rubocop', '~> 0.81.0')
   s.add_development_dependency('rubocop-performance', '~> 1.5.0')
-  s.add_development_dependency('rubocop-rspec', '~> 1.37.0')
+  s.add_development_dependency('rubocop-rspec', '~> 1.38.0')
   s.add_development_dependency('sqlite3', '~> 1.3')
 
   # For Documentation:


### PR DESCRIPTION
## Summary

Updates RuboCop and related gems. RuboCop is updated to the latest version that supports Ruby 2.3, which turns out to be 0.81.

## Details

See above. ~Apart from the above, autocorrects a performance offense.~

## Motivation and Context

Keeps stuff up-to-date.

## How Has This Been Tested?

I ran RuboCop. CI will have to check if the changes work on all supported Ruby versions.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
