### PR TITLE
Support for Ruby 2.4 through 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,34 @@ Metrics/BlockLength:
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only
 
+# Enable new cops
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Style/ExponentialNotation:
+  Enabled: true
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+Style/RedundantRegexpEscape:
+  Enabled: true
+Style/SlicingWithRange:
+  Enabled: true
+
 ## Cucumber Repo styles (Across implementations) ##
 
 Layout/LineLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     # These are auto-generated from a load of features that use aruba
     - 'tmp/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 dist: bionic
 
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
@@ -33,10 +32,6 @@ matrix:
   exclude:
   # Only test Rails6 on supported rubies
   # Don't test lowest rails support on maintained rubies
-    - rvm: 2.3
-      gemfile: gemfiles/rails_6_0.gemfile
-    - rvm: 2.4
-      gemfile: gemfiles/rails_4_2.gemfile
     - rvm: 2.4
       gemfile: gemfiles/rails_6_0.gemfile
     - rvm: 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - ruby-head
 
 addons:
@@ -41,6 +42,12 @@ matrix:
     - rvm: 2.6
       gemfile: gemfiles/rails_5_0.gemfile
     - rvm: 2.6
+      gemfile: gemfiles/rails_5_1.gemfile
+    - rvm: 2.7
+      gemfile: gemfiles/rails_4_2.gemfile
+    - rvm: 2.7
+      gemfile: gemfiles/rails_5_0.gemfile
+    - rvm: 2.7
       gemfile: gemfiles/rails_5_1.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails_4_2.gemfile

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rdoc', '>= 6.0')
   s.add_development_dependency('yard', '~> 0.9.10')
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.4.0'
   s.rubygems_version = '>= 1.6.1'
   s.files            = `git ls-files`.split("\n")
   s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -34,9 +34,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bundler', '>= 1.17')
   s.add_development_dependency('rake', '>= 12.0')
   s.add_development_dependency('rspec', '~> 3.6')
-  s.add_development_dependency('rubocop', '~> 0.81.0')
-  s.add_development_dependency('rubocop-performance', '~> 1.5.0')
-  s.add_development_dependency('rubocop-rspec', '~> 1.38.0')
+  s.add_development_dependency('rubocop', '~> 0.85.0')
+  s.add_development_dependency('rubocop-performance', '~> 1.6.1')
+  s.add_development_dependency('rubocop-rspec', '~> 1.39.0')
   s.add_development_dependency('sqlite3', '~> 1.3')
 
   # For Documentation:

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   # Main development dependencies
   s.add_development_dependency('ammeter', '>= 1.1.4')
   s.add_development_dependency('appraisal', '~> 2.2')
-  s.add_development_dependency('aruba', '~> 0.14.4')
+  s.add_development_dependency('aruba', '~> 1.0')
   s.add_development_dependency('bundler', '>= 1.17')
   s.add_development_dependency('rake', '>= 12.0')
   s.add_development_dependency('rspec', '~> 3.6')

--- a/features/step_definitions/cucumber_rails_steps.rb
+++ b/features/step_definitions/cucumber_rails_steps.rb
@@ -26,7 +26,7 @@ Given('I remove the {string} gem from the Gemfile') do |gem_name|
   new_content = []
 
   content.each do |line|
-    next if line =~ /gem ["|']#{gem_name}["|'].*/
+    next if /gem ["|']#{gem_name}["|'].*/.match?(line)
 
     new_content << line
   end

--- a/features/support/cucumber_rails_helper.rb
+++ b/features/support/cucumber_rails_helper.rb
@@ -25,7 +25,7 @@ module CucumberRailsHelper
     gem_regexp = /gem ["']#{name}["'].*$/
     gemfile_content = File.read(expand_path('Gemfile'))
 
-    if gemfile_content =~ gem_regexp
+    if gemfile_content&.match?(gem_regexp)
       updated_gemfile_content = gemfile_content.gsub(gem_regexp, line)
       overwrite_file('Gemfile', updated_gemfile_content)
     else


### PR DESCRIPTION
## Summary

Update the set of tested and supported Rubies to 2.4 - 2.7

## Details

- Bump minimum version in gemspec and rubocop config
- Stop building on 2.3 on Travis
- Start building on 2.7 on Travis
- Update rubocop and aruba dependencies, which also support Ruby 2.4+

## Motivation and Context

This relates to #455 and lowers the maintenance burden.

## How Has This Been Tested?

Travis will have to check on all supported Rubies.

## Types of changes

Not sure.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

Not sure yet either.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
