### PR TITLE
Compatibility with database_cleaner v2 adapter gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ on how to contribute to Cucumber.
 
 ### New Features
 
- * 
+ *
 
 ### Changed
 
@@ -13,7 +13,8 @@ on how to contribute to Cucumber.
 
 ### Fixed
 
- *
+ * Database cleaning no longer silently fails when using database_cleaner v2 adapter gems
+   ([#467](https://github.com/cucumber/cucumber-rails/pull/467) [botandrose])
 
 ## [v2.1.0](https://github.com/cucumber/cucumber-rails/compare/v2.0.0...v2.1.0) (2020-06-15)
 

--- a/features/database_cleaner.feature
+++ b/features/database_cleaner.feature
@@ -1,7 +1,50 @@
 Feature: Database Cleaner
 
-  Scenario: Create records in background
+  Scenario: Create records in background with database_cleaner
     Given I have created a new Rails app and installed cucumber-rails
+    When I write to "features/widgets.feature" with:
+      """
+      Feature: Create widgets
+        Background: 2 initial widgets
+          Given I have 2 widgets
+
+        Scenario: Add 3 widgets
+          When I create 3 more widgets
+          Then I should have 5 widgets
+
+        Scenario: Add 7 widgets
+          When I create 7 more widgets
+          Then I should have 9 widgets
+      """
+    And I run `rails generate model widget name:string`
+    And I write to "features/step_definitions/widget_steps.rb" with:
+      """
+      Given('I have {int} widgets') do |number|
+        number.times do |i|
+          Widget.create! name: "Widget #{Widget.count + i}"
+        end
+      end
+
+      When('I create {int} more widgets') do |number|
+        number.times do |i|
+          Widget.create! name: "Widget #{Widget.count + i}"
+        end
+      end
+
+      Then('I should have {int} widgets') do |number|
+        expect(Widget.count).to eq(number)
+      end
+      """
+    And I run `bundle exec rake db:migrate`
+    And I run `bundle exec rake cucumber`
+    Then the feature run should pass with:
+      """
+      2 scenarios (2 passed)
+      6 steps (6 passed)
+      """
+
+  Scenario: Create records in background with database_cleaner-active_record
+    Given I have created a new Rails app and installed cucumber-rails with database_cleaner-active_record
     When I write to "features/widgets.feature" with:
       """
       Feature: Create widgets

--- a/features/step_definitions/cucumber_rails_steps.rb
+++ b/features/step_definitions/cucumber_rails_steps.rb
@@ -10,6 +10,11 @@ Given('I have created a new Rails app and installed cucumber-rails') do
   install_cucumber_rails
 end
 
+Given('I have created a new Rails app and installed cucumber-rails with database_cleaner-active_record') do
+  rails_new
+  install_cucumber_rails :no_database_cleaner, :database_cleaner_active_record
+end
+
 Given('I have created a new Rails app with no database and installed cucumber-rails') do
   rails_new args: '--skip-active-record'
   install_cucumber_rails :no_database_cleaner, :no_factory_bot

--- a/features/support/cucumber_rails_helper.rb
+++ b/features/support/cucumber_rails_helper.rb
@@ -13,6 +13,7 @@ module CucumberRailsHelper
     add_gem 'selenium-webdriver', '~> 3.11', group: :test
     add_gem 'rspec-expectations', '~> 3.7', group: :test
     add_gem 'database_cleaner', '>= 1.8.0', group: :test unless options.include?(:no_database_cleaner)
+    add_gem 'database_cleaner-active_record', '>= 2.0.0.beta2', group: :test if options.include?(:database_cleaner_active_record)
     add_gem 'factory_bot', '>= 3.2', group: :test unless options.include?(:no_factory_bot)
 
     run_command_and_stop 'bundle install'

--- a/lib/cucumber/rails/hooks/database_cleaner.rb
+++ b/lib/cucumber/rails/hooks/database_cleaner.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 begin
-  require 'database_cleaner'
+  require 'database_cleaner/core'
+rescue LoadError
+  begin
+    require 'database_cleaner'
+  rescue LoadError
+    Cucumber.logger.debug('neither database_cleaner v1 or v2 present')
+  end
+end
 
+if defined?(DatabaseCleaner)
   Before('not @no-database-cleaner') do
     DatabaseCleaner.start if Cucumber::Rails::Database.autorun_database_cleaner
   end
@@ -10,6 +18,4 @@ begin
   After('not @no-database-cleaner') do
     DatabaseCleaner.clean if Cucumber::Rails::Database.autorun_database_cleaner
   end
-rescue LoadError
-  Cucumber.logger.debug('database_cleaner gem not present.')
 end


### PR DESCRIPTION
## Summary

Hi folks! This PR aims to resolve some incompatibilities with cucumber-rails and the upcoming major v2 release of database_cleaner.

## Details
In order to get access to the database_cleaner configuration in a ORM-agnostic way, we first try to require `database_cleaner/core` (which is only available in the database_cleaner v2 family of gems), then fall back to requiring `database_cleaner` for folks still on v1, finally falling back to silence if neither is available, since database_cleaner is an optional dependency.

## Motivation and Context

Last week, we cut beta versions of the next major version of database_cleaner. The main change here is that all of the ORM adapters have been split off into their own gems, e.g. database_cleaner-active_record, database_cleaner-redis, etc. Understanding that the majority of database_cleaner's current users are using it with Rails/ActiveRecord (and this gem, too), we chose to make the database_cleaner v2.0.0 gem a metagem that depends on database_cleaner-active_record, and simply loads that when `require "database_cleaner"` is run. This means that the vast majority of our users won't have to touch a thing to upgrade from database_cleaner v1 to v2. 

However, not everyone is only using ActiveRecord. There are those who can't get away with just leaving `gem "database_cleaner"` as-is in their Gemfile, and they have a bit more work to do. For example, let's say you're using Rails with Sequel and Redis, and want to upgrade to database_cleaner v2.0.0. No big deal, you just replace `gem "database_cleaner"` with `gem "database_cleaner-sequel"` and `gem "database_cleaner-redis"` and you're good to go. However, in this situation, the current implementation of cucumber-rails' database_cleaner integration will silently fail.

The underlying issue is that none of the ORM adapters have a `lib/database_cleaner.rb` file (only the database_cleaner metagem has it, for backwards compatibility with the common case), so the `require "database_cleaner"` call in the "lib/cucumber/rails/hooks/database_cleaner.rb" will silently fail since `LoadError` is being caught and discarded, the only visible clue being that the database state is now persisting between test cases. Personally, I consider this issue to be a blocker for releasing final v2.0.0 versions of the database_cleaner family of gems.

## How Has This Been Tested?

The first commit in this PR adds a new cucumber feature that fails, exposing this issue. It does this by simply adding `gem "database_cleaner-active_record"` to the Gemfile, instead of `gem "database_cleaner"`. This was the simplest way to expose the issue without adding a dev dependency on another ORM. This is also a valid and supported way to use database_cleaner with ActiveRecord, BTW.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

This change should be transparent to consumers of the library.