### PR TITLE
Restore compatibility with database_cleaner < 1.8.0.beta

### DIFF
--- a/lib/cucumber/rails/database.rb
+++ b/lib/cucumber/rails/database.rb
@@ -76,7 +76,7 @@ module Cucumber
         end
 
         def before_js(strategy)
-          @original_strategy = if Gem::Version.new(DatabaseCleaner::VERSION) >= Gem::Version.new('1.8.0.beta')
+          @original_strategy = if defined?(DatabaseCleaner::VERSION) && Gem::Version.new(DatabaseCleaner::VERSION) >= Gem::Version.new('1.8.0.beta')
                                  DatabaseCleaner.cleaners.values.first.strategy # that feels like a nasty hack
                                else
                                  DatabaseCleaner.connections.first.strategy # that feels like a nasty hack


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please choose a concise, descriptive name for your pull request. -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

<!--- Provide a general summary description of your changes -->
`DatabaseCleaner::VERSION` didn't exist until `1.8.0.beta`, so having an older version causes an uninitialized constant error instead of using the old behavior.

## Details

<!--- Describe your changes in detail -->
When upgrading the cucumber-rails 2.1, my @javascript scenarios failed with `uninitialized constant DatabaseCleaner::VERSION (NameError)` errors. cucumber-rails has conditional logic checking if `DatabaseCleaner::VERSION` is greater than or equal to `1.8.0.beta`, but `DatabaseCleaner::VERSION` [didn't exist until `1.8.0.beta`](https://github.com/DatabaseCleaner/database_cleaner/commit/db6b5d1d547647cbb5c07ecd5740019d2493dd2b#diff-c4f8e099c1ca7e218458213e7c82ac59).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The code change that added support for newer versions of Database Cleaner was written with the intention of maintaining support for older versions of Database Cleaner, but it failed in practice. This change restores compatibility with older versions.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested with my app still using Database Cleaner 1.7.0. It failed when using the release version of cucumber-rails 2.1, but succeeded using the versions of cucumber-rails in this pull request.

I did not add an automated test because, outside of Rails itself, the project doesn't seem to take on the overhead of testing with older versions of libraries and an automated test for backwards compatibility wasn't added with the original change. If I'm wrong in that assessment, I'm happy to add an automated test however the project would like.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
