### PR TITLE
Restore previous behavior where ActiveRecord hooks are conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ on how to contribute to Cucumber.
 
  * Database cleaning no longer silently fails when using database_cleaner v2 adapter gems
    ([#467](https://github.com/cucumber/cucumber-rails/pull/467) [botandrose])
+ * Restored compatibility with `database_cleaner` versions earlier than 1.8.0.beta
+   ([#473](https://github.com/cucumber/cucumber-rails/pull/473) [cgriego])
+ * Restored previous `database_cleaner` behavior for apps that do not use/load ActiveRecord
+   ([#474](https://github.com/cucumber/cucumber-rails/pull/474) [cgriego])
 
 ## [v2.1.0](https://github.com/cucumber/cucumber-rails/compare/v2.0.0...v2.1.0) (2020-06-15)
 

--- a/lib/cucumber/rails/hooks/active_record.rb
+++ b/lib/cucumber/rails/hooks/active_record.rb
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 
-module ActiveRecord
-  class Base
-    class_attribute :shared_connection
+if defined?(ActiveRecord::Base)
+  module ActiveRecord
+    class Base
+      class_attribute :shared_connection
 
-    def self.connection
-      shared_connection || retrieve_connection
+      def self.connection
+        shared_connection || retrieve_connection
+      end
     end
   end
-end
 
-Before('@javascript') do
-  Cucumber::Rails::Database.before_js if Cucumber::Rails::Database.autorun_database_cleaner
-end
+  Before('@javascript') do
+    Cucumber::Rails::Database.before_js if Cucumber::Rails::Database.autorun_database_cleaner
+  end
 
-Before('not @javascript') do
-  Cucumber::Rails::Database.before_non_js if Cucumber::Rails::Database.autorun_database_cleaner
-end
+  Before('not @javascript') do
+    Cucumber::Rails::Database.before_non_js if Cucumber::Rails::Database.autorun_database_cleaner
+  end
 
-After do
-  Cucumber::Rails::Database.after if Cucumber::Rails::Database.autorun_database_cleaner
+  After do
+    Cucumber::Rails::Database.after if Cucumber::Rails::Database.autorun_database_cleaner
+  end
 end


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please choose a concise, descriptive name for your pull request. -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

<!--- Provide a general summary description of your changes -->
This commit reverts part of 9f18bb437cd8039aaa4d9f19f67544211205ace3.

While Rails has included ActiveRecord since the very beginning, not every Rails app uses ActiveRecord or even loads ActiveRecord. Some use alternative databases entirely.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The commit mentioned above asserts that conditionals on ActiveRecord are not necessary for cucumber-rails because Rails includes ActiveRecord and always has. The problem is that not every Rails app uses or loads ActiveRecord. This was in fact a cornerstone of the Rails 3 release where the components were made more easily replaceable, which led to the introduction of the `Railtie` class and the ActiveModel library.

The portion of the commit that was not reverted deals with requiring the `rails/test_help` file and doing so unconditionally. This is a reasonable change to keep, in part because that file, within Rails core itself, has [conditional logic for ActiveRecord being loaded](https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/railties/lib/rails/test_help.rb#L15).

By not having conditional logic, cucumber-rails is in fact defining an `ActiveRecord::Base` class, which trips up library code that does the type of detection seen in Rails core and being restored by this pull request, causing failures.

Alternatively I've had to work around this in my own app using multiple MongoDB databases without ActiveRecord by defining a custom JavaScript strategy class.

```ruby
class CucumberHandsOffStrategy
  def before_js
  end

  def before_non_js
  end

  def after
  end
end

Cucumber::Rails::Database.javascript_strategy = CucumberHandsOffStrategy
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
