### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rspec
   - rubocop-performance
+  - rubocop-packaging
 
 AllCops:
   TargetRubyVersion: 2.4

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'rake/file_list'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |s|
@@ -35,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake', '>= 12.0')
   s.add_development_dependency('rspec', '~> 3.6')
   s.add_development_dependency('rubocop', '~> 0.85.0')
+  s.add_development_dependency('rubocop-packaging', '~> 0.1.1')
   s.add_development_dependency('rubocop-performance', '~> 1.6.1')
   s.add_development_dependency('rubocop-rspec', '~> 1.39.0')
   s.add_development_dependency('sqlite3', '~> 1.3')
@@ -45,7 +47,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4.0'
   s.rubygems_version = '>= 1.6.1'
-  s.files            = `git ls-files`.split("\n")
-  s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")
+  s.files            = Rake::FileList['**/*'].exclude(*File.read('.gitignore').split)
+  s.test_files       = Dir['{spec,features}/**/*']
   s.require_path     = 'lib'
 end


### PR DESCRIPTION
Hi,

Thanks again for working on this! :heart: 
However, while maintaining this in Debian, we found that this library relies on `git` to list the files which could be done via pure Ruby alternative -- which is what this PR does.

Also, added rubocop-packaging as a `development_dependency` which will ensure the best practices.
Here's what it shows:

```
Inspecting 33 files
...C.............................

Offenses:

cucumber-rails.gemspec:49:24: C: Packaging/GemspecGit: Avoid using git to produce lists of files.
Downstreams often need to build your package in an environment that does not have git (on purpose).
Use some pure Ruby alternative, like Dir or Dir.glob.
  s.files            = `git ls-files`.split("\n")
                       ^^^^^^^^^^^^^^

cucumber-rails.gemspec:50:24: C: Packaging/GemspecGit: Avoid using git to produce lists of files.
Downstreams often need to build your package in an environment that does not have git (on purpose).
Use some pure Ruby alternative, like Dir or Dir.glob.
  s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


33 files inspected, 2 offense detected
```

And this PR fixes the same, which helps us in shipping this in Debian! :tada: 
Hope this would make sense and you'll be open to this change :100: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>

---

CC: @luke-hill :smile: 
Closes: #475