### PR TITLE
Update RuboCop dependencies and fix new offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.4
+  NewCops: enable
   Exclude:
     # These are auto-generated from a load of features that use aruba
     - 'tmp/**/*'
@@ -20,34 +21,6 @@ Metrics/BlockLength:
 # This allows us to read the chmod action in a more reproducible way
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only
-
-# Enable new cops
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-Lint/RaiseException:
-  Enabled: true
-Lint/StructNewOverride:
-  Enabled: true
-Style/ExponentialNotation:
-  Enabled: true
-Style/HashEachMethods:
-  Enabled: true
-Style/HashTransformKeys:
-  Enabled: true
-Style/HashTransformValues:
-  Enabled: true
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-Style/RedundantRegexpEscape:
-  Enabled: true
-Style/SlicingWithRange:
-  Enabled: true
 
 ## Cucumber Repo styles (Across implementations) ##
 

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop', '~> 0.88.0')
   s.add_development_dependency('rubocop-packaging', '~> 0.2.0')
   s.add_development_dependency('rubocop-performance', '~> 1.7.1')
-  s.add_development_dependency('rubocop-rspec', '~> 1.39.0')
+  s.add_development_dependency('rubocop-rspec', '~> 1.42.0')
   s.add_development_dependency('sqlite3', '~> 1.3')
 
   # For Documentation:

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake', '>= 12.0')
   s.add_development_dependency('rspec', '~> 3.6')
   s.add_development_dependency('rubocop', '~> 0.88.0')
-  s.add_development_dependency('rubocop-packaging', '~> 0.1.1')
+  s.add_development_dependency('rubocop-packaging', '~> 0.2.0')
   s.add_development_dependency('rubocop-performance', '~> 1.6.1')
   s.add_development_dependency('rubocop-rspec', '~> 1.39.0')
   s.add_development_dependency('sqlite3', '~> 1.3')

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3.6')
   s.add_development_dependency('rubocop', '~> 0.88.0')
   s.add_development_dependency('rubocop-packaging', '~> 0.2.0')
-  s.add_development_dependency('rubocop-performance', '~> 1.6.1')
+  s.add_development_dependency('rubocop-performance', '~> 1.7.1')
   s.add_development_dependency('rubocop-rspec', '~> 1.39.0')
   s.add_development_dependency('sqlite3', '~> 1.3')
 

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bundler', '>= 1.17')
   s.add_development_dependency('rake', '>= 12.0')
   s.add_development_dependency('rspec', '~> 3.6')
-  s.add_development_dependency('rubocop', '~> 0.85.0')
+  s.add_development_dependency('rubocop', '~> 0.88.0')
   s.add_development_dependency('rubocop-packaging', '~> 0.1.1')
   s.add_development_dependency('rubocop-performance', '~> 1.6.1')
   s.add_development_dependency('rubocop-rspec', '~> 1.39.0')

--- a/lib/cucumber/rails.rb
+++ b/lib/cucumber/rails.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-called_from_env_rb = caller.detect { |f| f =~ /\/env\.rb:/ }
+called_from_env_rb = caller.detect { |f| f.include? '/env.rb:' }
 
 if called_from_env_rb
   env_caller = File.dirname(called_from_env_rb)


### PR DESCRIPTION
## Summary

Update RuboCop dependencies, enable new cops by default, and fix new offense

## Details

- Updates rubocop, rubocop-rspec, rubocop-performance and rubocop-packaging to their latest versions
- Enables new cops by default instead of having to enable each separately. Since versions of the rubocop gems are updated carefully, this turns out to be less work in general
- Fix new Performance/StringInclude offense

## Motivation and Context

Keeps things up-to-date

## How Has This Been Tested?

I ran rubocop to check that it's clean now.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
