### PR TITLE
Check for ActionMailer before adding mailer hook

### DIFF
--- a/lib/cucumber/rails/hooks/mail.rb
+++ b/lib/cucumber/rails/hooks/mail.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-Before do
-  ActionMailer::Base.deliveries = []
+if defined?(::ActionMailer)
+  Before do
+    ActionMailer::Base.deliveries = []
+  end
 end


### PR DESCRIPTION
## Summary

ActionMailer is optional on Rails and should also be optional here.

By checking for the presence of the class, we allow apps that don't use action mailer to use the gem.

## Motivation and Context

This change is harmless and makes the gem compatible with more apps.

## How Has This Been Tested?

Edited the gem on my local machine and cucumber runs after the change

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.