### PR TITLE
Fix the version number for latest release in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ on how to contribute to Cucumber.
 
  *
 
-## [master](https://github.com/cucumber/cucumber-rails/compare/v2.1.0...v2.2.0) (2020-08-10)
+## [v2.2.0](https://github.com/cucumber/cucumber-rails/compare/v2.1.0...v2.2.0) (2020-08-10)
 
 ### New Features
 


### PR DESCRIPTION
## Summary

## Motivation and Context

I was updating some dependencies in my project and went through the changelogs for the outdated gems. Then I found that the latest release wasn't renamed to the version number in the changelog

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Fix in the documentation

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
