### PR TITLE
Bump RuboCop::Packaging to v0.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,9 @@
 inherit_from: .rubocop_todo.yml
 
 require:
-  - rubocop-rspec
-  - rubocop-performance
   - rubocop-packaging
+  - rubocop-performance
+  - rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 2.4

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake', '>= 12.0')
   s.add_development_dependency('rspec', '~> 3.6')
   s.add_development_dependency('rubocop', '~> 0.89.0')
-  s.add_development_dependency('rubocop-packaging', '~> 0.3.0')
+  s.add_development_dependency('rubocop-packaging', '~> 0.5.1')
   s.add_development_dependency('rubocop-performance', '~> 1.7.1')
   s.add_development_dependency('rubocop-rspec', '~> 1.42.0')
   s.add_development_dependency('sqlite3', '~> 1.3')


### PR DESCRIPTION
RuboCop::Packaging through v0.5 supports
autocorrect for its cops. Thus worth bumping
the version from v0.3 to v0.5.

And also sort the list of extensions alphabetically.

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>