### PR TITLE
CHANGELOG: fix Markdown link to a user which lacked a link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ on how to contribute to Cucumber.
 
 ### Changed
 
- * Changed dependency from rails to railties to avoid pulling in optional Rails gems like actioncable ([#486](https://github.com/cucumber/cucumber-rails/pull/486) [langalex]).
+ * Changed dependency from rails to railties to avoid pulling in optional Rails gems like actioncable ([#486](https://github.com/cucumber/cucumber-rails/pull/486)  [langalex]).
 
 ### Fixed
 
@@ -652,3 +652,4 @@ and to celebrate that cucumber-rails now supports Capybara as an alternative to 
 [cgriego]: https://github.com/cgriego
 [botandrose]: https://github.com/botandrose
 [Draiken]: https://github.com/Draiken
+[langalex]: https://github.com/langalex


### PR DESCRIPTION


## Summary

An author was missing a reference-style link in the Markdown document.

## Details

Add a link in there.

## Motivation and Context

Makes the CHANGELOG render right.

## How Has This Been Tested?

Preview the Markdown.

## Types of changes

- [x] Bug fix

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
