### PR TITLE
Silence warnings about puts versus log

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -2,7 +2,7 @@
 
 After do |scenario|
   if scenario.failed?
-    puts last_command_stopped.stdout
-    puts last_command_stopped.stderr
+    log last_command_stopped.stdout
+    log last_command_stopped.stderr
   end
 end


### PR DESCRIPTION
## Summary

Replace puts with log to silence Cucumber warnings.

## Details

This replaces puts with log in the After scenario hook that prints output of failed commands when the scenario fails.

## Motivation and Context

Cucumber's old puts behavior is deprecated. This change silences warnings from Cucumber about this.

## How Has This Been Tested?

I re-ran one scenario that fails on my machine to see if the warnings disappeared.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.