### PR TITLE
Raise useful error if no DatabaseCleaner strategies are loaded

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('appraisal', '~> 2.2')
   s.add_development_dependency('aruba', '~> 1.0')
   s.add_development_dependency('bundler', '>= 1.17')
+  s.add_development_dependency('database_cleaner', ['>= 1.8', '< 3.0'])
   s.add_development_dependency('rake', '>= 12.0')
   s.add_development_dependency('rspec', '~> 3.6')
   s.add_development_dependency('rubocop', '~> 0.93.0')

--- a/lib/cucumber/rails/database/strategy.rb
+++ b/lib/cucumber/rails/database/strategy.rb
@@ -10,6 +10,9 @@ module Cucumber
 
         def before_js(strategy)
           @original_strategy = if defined?(DatabaseCleaner::VERSION) && Gem::Version.new(DatabaseCleaner::VERSION) >= Gem::Version.new('1.8.0.beta')
+                                 if DatabaseCleaner.cleaners.empty?
+                                   raise "No DatabaseCleaner strategies found. Make sure you have required one of DatabaseCleaner's adapters"
+                                 end
                                  DatabaseCleaner.cleaners.values.first.strategy # that feels like a nasty hack
                                else
                                  DatabaseCleaner.connections.first.strategy # that feels like a nasty hack

--- a/spec/cucumber/rails/database_spec.rb
+++ b/spec/cucumber/rails/database_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'database_cleaner'
 require 'cucumber/rails/database/strategy'
 require 'cucumber/rails/database/deletion_strategy'
 require 'cucumber/rails/database/shared_connection_strategy'
@@ -21,6 +22,13 @@ describe Cucumber::Rails::Database do
       expect(strategy).to receive(:before_js)
 
       described_class.before_js
+    end
+
+    it 'raises an error on `before_js` if no DatabaseCleaner cleaners exist' do
+      allow(DatabaseCleaner).to receive(:cleaners).and_return({})
+
+      expect { described_class.before_js }
+        .to raise_error /No DatabaseCleaner strategies found/
     end
   end
 

--- a/spec/cucumber/rails/database_spec.rb
+++ b/spec/cucumber/rails/database_spec.rb
@@ -8,8 +8,9 @@ require 'cucumber/rails/database/truncation_strategy'
 require 'cucumber/rails/database'
 
 describe Cucumber::Rails::Database do
+  let(:strategy) { described_class.instance_eval { @strategy } }
+
   context 'when using a valid pre-determined strategy' do
-    let(:strategy) { described_class.instance_eval { @strategy } }
     before { described_class.javascript_strategy = :truncation }
 
     it 'forwards a `before_non_js` event to the selected strategy' do
@@ -40,7 +41,6 @@ describe Cucumber::Rails::Database do
   end
 
   context 'when using a valid custom strategy' do
-    let(:strategy) { described_class.instance_eval { @strategy } }
     let(:strategy_type) do
       Class.new do
         def before_js

--- a/spec/cucumber/rails/database_spec.rb
+++ b/spec/cucumber/rails/database_spec.rb
@@ -7,12 +7,8 @@ require 'cucumber/rails/database/truncation_strategy'
 require 'cucumber/rails/database'
 
 describe Cucumber::Rails::Database do
-  before { allow(strategy_type).to receive(:new).and_return(strategy) }
-
-  let(:strategy) { instance_double(strategy_type, before_js: nil, before_non_js: nil) }
-  let(:strategy_type) { Cucumber::Rails::Database::TruncationStrategy }
-
   context 'when using a valid pre-determined strategy' do
+    let(:strategy) { described_class.instance_eval { @strategy } }
     before { described_class.javascript_strategy = :truncation }
 
     it 'forwards a `before_non_js` event to the selected strategy' do
@@ -36,8 +32,7 @@ describe Cucumber::Rails::Database do
   end
 
   context 'when using a valid custom strategy' do
-    before { described_class.javascript_strategy = strategy_type }
-
+    let(:strategy) { described_class.instance_eval { @strategy } }
     let(:strategy_type) do
       Class.new do
         def before_js
@@ -49,6 +44,8 @@ describe Cucumber::Rails::Database do
         end
       end
     end
+
+    before { described_class.javascript_strategy = strategy_type }
 
     it 'forwards a `before_non_js` event to the strategy' do
       expect(strategy).to receive(:before_non_js)


### PR DESCRIPTION
## Summary

Raise useful error if no DatabaseCleaner strategies are loaded

## Details

When `#before_js` is called on a Strategy, bail out if DatabaseCleaner.cleaners is empty.

## Motivation and Context

This fixes #491.

## How Has This Been Tested?

I added a spec and made it pass.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.