### PR TITLE
Skip Javascript when creating a Rails application in test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,6 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/features/support/cucumber_rails_helper.rb
+++ b/features/support/cucumber_rails_helper.rb
@@ -17,7 +17,6 @@ module CucumberRailsHelper
     add_gem 'factory_bot', '>= 3.2', group: :test unless options.include?(:no_factory_bot)
 
     run_command_and_stop 'bundle install'
-    run_command_and_stop 'bundle exec rails webpacker:install' if rails6?
     run_command_and_stop 'bundle exec rails generate cucumber:install'
   end
 
@@ -38,8 +37,7 @@ module CucumberRailsHelper
 
   def run_rails_new_command(options)
     options[:name] ||= 'test_app'
-    flags = '--skip-bundle --skip-test-unit --skip-spring --skip-bootsnap'
-    flags += ' --skip-webpack-install' if rails6?
+    flags = '--skip-bundle --skip-test-unit --skip-spring --skip-bootsnap --skip-javascript'
     run_command "bundle exec rails new #{options[:name]} #{flags} #{options[:args]}"
   end
 


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please choose a concise, descriptive name for your pull request. -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Speed up the CI build by instructing Rails to skip Javascript when creating a new application.

## Details

In the Cucumber test suite for this gem, multiple temporary Rails applications are created to exercise the integration. For the Rails 6.0 test jobs in-particular, this is extremely slow. The `webpacker:install` step takes a long time to complete.

By removing this step and instructing Rails to skip installing Javascript configuration, we can speed up the build. The Rails 6.0 test job build times are improved by at least 50%! From ~20mins to <10mins.

## Motivation and Context

It's frustrating to wait for a slow CI build. Developers want feedback ASAP.

## How Has This Been Tested?

CI configuration change only. The CI build passes.
<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
