### PR TITLE
Optimise CI test suite

### DIFF
--- a/features/no_database.feature
+++ b/features/no_database.feature
@@ -10,8 +10,6 @@ Feature: No Database
       require File.expand_path('../boot', __FILE__)
 
       require 'action_controller/railtie'
-      require 'action_mailer/railtie'
-      require 'rails/test_unit/railtie'
 
       Bundler.require(:default, Rails.env) if defined?(Bundler)
 

--- a/features/rerun_profile.feature
+++ b/features/rerun_profile.feature
@@ -26,7 +26,7 @@ Feature: Rerun profile
     And a file named "features/step_definitions/rerun_steps.rb" with:
       """
       Given('fixed now') do
-        log 'All fixed now'
+        $stdout.puts 'All fixed now'
       end
 
       Given('broken') do
@@ -34,7 +34,7 @@ Feature: Rerun profile
       end
 
       Given('passing') do
-        log "I've always been passing"
+        $stdout.puts "I've always been passing"
       end
       """
     When I run `bundle exec cucumber -p rerun`

--- a/features/support/cucumber_rails_helper.rb
+++ b/features/support/cucumber_rails_helper.rb
@@ -48,6 +48,7 @@ module CucumberRailsHelper
 
   def bundle_install
     run_command_and_stop 'bundle config set --local without "development"'
+    run_command_and_stop "bundle config set --local path '#{ENV['GITHUB_WORKSPACE']}/vendor/bundle'" if ENV.key?('GITHUB_WORKSPACE')
     run_command_and_stop 'bundle install'
   end
 

--- a/features/support/cucumber_rails_helper.rb
+++ b/features/support/cucumber_rails_helper.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
+require 'rails'
+
 module CucumberRailsHelper
   def rails_new(options = {})
     validate_rails_new_success(run_rails_new_command(options))
-    clear_bundle_env_vars(options[:name])
+    cd options[:name]
+    configure_rails_gems
+    configure_rails_requires
+    configure_rails_layout
+    clear_bundle_env_vars
   end
 
   def install_cucumber_rails(*options)
@@ -16,9 +22,11 @@ module CucumberRailsHelper
     add_gem 'database_cleaner-active_record', '>= 2.0.0.beta2', group: :test if options.include?(:database_cleaner_active_record)
     add_gem 'factory_bot', '>= 3.2', group: :test unless options.include?(:no_factory_bot)
 
-    run_command_and_stop 'bundle install'
+    bundle_install
     run_command_and_stop 'bundle exec rails generate cucumber:install'
   end
+
+  private
 
   def add_gem(name, *args)
     line = convert_gem_opts_to_string(name, *args)
@@ -33,12 +41,43 @@ module CucumberRailsHelper
     end
   end
 
-  private
+  def remove_gem(name)
+    content = File.read(expand_path('Gemfile')).gsub(/^\s*gem ["']#{name}["'].*$/, '')
+    overwrite_file('Gemfile', content)
+  end
+
+  def bundle_install
+    run_command_and_stop 'bundle config set --local without "development"'
+    run_command_and_stop 'bundle install'
+  end
+
+  def configure_rails_gems
+    %w[bootsnap byebug jbuilder listen rails sass-rails turbolinks webpacker].each { |gem| remove_gem(gem) }
+    %w[railties activerecord actionpack].each { |rails_gem| add_gem(rails_gem, Rails.version) }
+  end
+
+  def configure_rails_requires
+    content = File.read(expand_path('config/application.rb'))
+    %w[ active_job/railtie active_storage/engine action_mailer/railtie action_mailbox/engine
+        action_text/engine action_cable/engine rails/test_unit/railtie sprockets/railtie ].each do |require|
+      content = content.gsub(/^.*require ["']#{require}["']\s*$/, '')
+    end
+    overwrite_file('config/application.rb', content)
+  end
+
+  def configure_rails_layout
+    file = 'app/views/layouts/application.html.erb'
+    content = File.read(expand_path(file)).gsub(/^\s*<%= stylesheet_link_tag .*%>\s*$/, '')
+    overwrite_file(file, content)
+  end
 
   def run_rails_new_command(options)
     options[:name] ||= 'test_app'
-    flags = '--skip-bundle --skip-test-unit --skip-spring --skip-bootsnap --skip-javascript'
-    run_command "bundle exec rails new #{options[:name]} #{flags} #{options[:args]}"
+    flags = %w[ --skip-action-cable --skip-action-mailer --skip-active-job --skip-bootsnap --skip-bundle --skip-javascript
+                --skip-jbuilder --skip-listen --skip-spring --skip-sprockets --skip-test-unit --skip-turbolinks ]
+    flags += %w[--skip-active-storage] if rails_5_2_or_higher?
+    flags += %w[--skip-action-mailbox --skip-action-text] if rails_6_0_or_higher?
+    run_command "bundle exec rails new #{options[:name]} #{flags.join(' ')} #{options[:args]}"
   end
 
   def validate_rails_new_success(result)
@@ -46,14 +85,17 @@ module CucumberRailsHelper
     expect(last_command_started).to be_successfully_executed
   end
 
-  def clear_bundle_env_vars(dir)
-    cd dir
+  def clear_bundle_env_vars
     unset_bundler_env_vars
     delete_environment_variable 'BUNDLE_GEMFILE'
   end
 
-  def rails6?
-    `bundle exec rails -v`.start_with?('Rails 6')
+  def rails_5_2_or_higher?
+    Rails.gem_version >= Gem::Version.new('5.2')
+  end
+
+  def rails_6_0_or_higher?
+    Rails.gem_version >= Gem::Version.new('6.0')
   end
 
   def add_conditional_gems(options)
@@ -63,7 +105,7 @@ module CucumberRailsHelper
       add_gem 'cucumber-rails', group: :test, require: false, path: File.expand_path('.').to_s
     end
 
-    if rails6?
+    if rails_6_0_or_higher?
       add_gem 'sqlite3', '~> 1.4'
     else
       add_gem 'sqlite3', '~> 1.3.13'

--- a/features/support/cucumber_rails_helper.rb
+++ b/features/support/cucumber_rails_helper.rb
@@ -49,7 +49,7 @@ module CucumberRailsHelper
   def bundle_install
     run_command_and_stop 'bundle config set --local without "development"'
     run_command_and_stop "bundle config set --local path '#{ENV['GITHUB_WORKSPACE']}/vendor/bundle'" if ENV.key?('GITHUB_WORKSPACE')
-    run_command_and_stop 'bundle install'
+    run_command_and_stop 'bundle install --jobs 4'
   end
 
   def configure_rails_gems

--- a/features/support/cucumber_rails_helper.rb
+++ b/features/support/cucumber_rails_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'rails'
+require 'cucumber'
+require 'capybara'
 
 module CucumberRailsHelper
   def rails_new(options = {})
@@ -15,7 +17,8 @@ module CucumberRailsHelper
   def install_cucumber_rails(*options)
     add_conditional_gems(options)
 
-    add_gem 'capybara', group: :test
+    add_gem 'cucumber', Cucumber::VERSION, group: :test
+    add_gem 'capybara', Capybara::VERSION, group: :test
     add_gem 'selenium-webdriver', '~> 3.11', group: :test
     add_gem 'rspec-expectations', '~> 3.7', group: :test
     add_gem 'database_cleaner', '>= 1.8.0', group: :test unless options.include?(:no_database_cleaner)


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please choose a concise, descriptive name for your pull request. -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

### Context

The Cucumber test suite for this gem can take some time to run. It'd be great to speed this up and provide a faster feedback loop for developers.

Each scenario of the Cucumber test suite creates a temporary Rails application with which to test the `cucumber-rails` integration. There are optimisations that can be made to reduce the time spent creating these Rails applications.


### Change

This proposal focuses on the gem installation of the Rails applications. With these four optimisations, the CI build is reduced from **~10** minutes to **~5** minutes!

- **Avoid installing unnecessary gems**: The Rails framework provides much functionality. The `cucumber-ralis` gem only integrations with a small portion of this functionality. All we need to provide confidence, is the MVC functionality provided by Rails. By reducing the gems used by each temporary Rails application we can avoid downloading, compiling and loading superfluous gems. For example, the `sassc` gem used in Rails 6.0 can take a couple of minutes to compile native extensions.

- **Use GitHub workspace gem cache**: The `ruby/setup-ruby` action used to install Ruby and run `bundle install` provides a [fantastic caching capability](https://github.com/ruby/setup-ruby#caching-bundle-install-automatically). This means gems, as specified in the Appraisal gemfiles, are cached between builds. By configuring the temporary Rails apps to use the same Bundle path, we can avoid re-installing the in-common gems.

- **Use versions of Cucumber and Capybara as constrained in the Appraisal gemfiles**: Ensure the version of Cucumber and Capybara used in the temporary Rails apps match the version used in the Appraisal gemfile. This increases the gems in-common between the two installs, increasing the effectiveness of sharing the Bundle path location. For example, in the `rails_5_0` gem file, `cucumber < 4` is specified, however the temporary Rails applications would not follow this constraint and use version 5.
 
  This change also increases confidence that `cucumber-rails` integrates correctly with the versions of gems as constrained via the Appraisal gemfiles. 

- **Install gems in parallel**: By installing four gems at a time we can shave a few seconds of the build time.




### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No production code changed.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
