### PR TITLE
Remove instruction to install a Javascript runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,3 @@ For example, rspec is a primary development dependency, so it lives in the gemsp
 
 [the helper]: https://github.com/cucumber/cucumber-rails/blob/5e37c530560ae1c1a79521c38a54bae0be94242b/features/step_definitions/cucumber_rails_steps.rb#L15
 
-### NOTE
-
-If you get an error while trying to run the tests locally, similar to the one below:
-
-    Could not find a JavaScript runtime. See https://github.com/sstephenson/execjs for a list of available runtimes. (ExecJS::RuntimeUnavailable)
-    
-You need to install a javascript runtime.
-
-You can do that in ubuntu by using:
-
-    sudo apt-get install nodejs


### PR DESCRIPTION
### Change

Since #506, the test suite no longer requires a Javascript runtime. Remove the instruction to install one from the README document.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
