### PR TITLE
Add support for Ruby 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0' ]
         gemfile: [ 'rails_5_0', 'rails_5_1', 'rails_5_2', 'rails_6_0', 'rails_6_1' ]
         exclude:
           # Only test latest Rails (Of each major), on actively supported Ruby Versions
@@ -16,6 +16,7 @@ jobs:
           # 2.5  -> Not 5.2/6.1
           # 2.6  -> Users of this should be using Rails 5.2+
           # 2.7  -> Users of this should be using Rails 5.2+
+          # 3.0  -> Only Rails 6.1
           - { ruby: '2.4', gemfile: 'rails_5_2' }
           - { ruby: '2.4', gemfile: 'rails_6_0' }
           - { ruby: '2.4', gemfile: 'rails_6_1' }
@@ -25,6 +26,10 @@ jobs:
           - { ruby: '2.6', gemfile: 'rails_5_1' }
           - { ruby: '2.7', gemfile: 'rails_5_0' }
           - { ruby: '2.7', gemfile: 'rails_5_1' }
+          - { ruby: '3.0', gemfile: 'rails_5_0' }
+          - { ruby: '3.0', gemfile: 'rails_5_1' }
+          - { ruby: '3.0', gemfile: 'rails_5_2' }
+          - { ruby: '3.0', gemfile: 'rails_6_0' }
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ on how to contribute to Cucumber.
 
 ### Fixed
 
+*
 
 ## [v2.3.0](https://github.com/cucumber/cucumber-rails/compare/v2.2.0...v2.3.0) (2021-03-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ on how to contribute to Cucumber.
 ### New Features
 
 * Added new docker / Makefile script to permit releasing from repo ([#502](https://github.com/cucumber/cucumber-rails/pull/502) [luke-hill])
+* Gem update: allowed cucumber 6 ([#515](https://github.com/cucumber/cucumber-rails/pull/515))
+* Add support for Ruby 3 ([#517](https://github.com/cucumber/cucumber-rails/pull/517/))
 
 ### Changed
 
@@ -13,7 +15,7 @@ on how to contribute to Cucumber.
 
 ### Fixed
 
-* 
+*
 
 ## [v2.3.0](https://github.com/cucumber/cucumber-rails/compare/v2.2.0...v2.3.0) (2021-03-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ on how to contribute to Cucumber.
 
 ### Fixed
 
-*
 
 ## [v2.3.0](https://github.com/cucumber/cucumber-rails/compare/v2.2.0...v2.3.0) (2021-03-30)
 

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('mime-types', ['~> 3.2']) # Only support the latest major (3+ years old)
   s.add_runtime_dependency('nokogiri', '~> 1.8') # Only support the latest major (3+ years old)
   s.add_runtime_dependency('railties', ['>= 5.0', '< 7']) # We support any version of Rails in the 5.x and 6.x series
+  s.add_runtime_dependency('rexml', '~> 3.0') # rexml is a bundled gem since ruby 3
+  s.add_runtime_dependency('webrick', '~> 1.7') # webrick is a bundled gem since ruby 3
 
   # Main development dependencies
   s.add_development_dependency('ammeter', '>= 1.1.4')


### PR DESCRIPTION
Attempt to add support for Ruby 3.

I've added a new entry in the build matrix. Ruby 3 is only properly supported with Rails 6.1.

I have updated the runtime dependencies in the gemspec. I have tried other ways without success.