### PR TITLE
null database strategy to disable @javascript handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ on how to contribute to Cucumber.
 
 ### New Features
 
-* 
+* Added `:none` option for `javascript_strategy` which indicates no special handling of `@javascript` tagged tests ([#522](https://github.com/cucumber/cucumber-rails/pull/522) [akostadinov])
 
 ### Changed
 

--- a/features/choose_javascript_database_strategy.feature
+++ b/features/choose_javascript_database_strategy.feature
@@ -20,8 +20,11 @@ Feature: Choose javascript database strategy
   Right now, the default behavior is to use truncation, but you can override this by telling
   cucumber-rails which strategy to use for javascript scenarios.
 
-  The deletion strategy can be quicker for situations where truncation causes locks which
+  The `:deletion` strategy can be quicker for situations where truncation causes locks which
   has been reported by some Oracle users.
+
+  The `:none` strategy can be used when user doesn't want special handling of scenario
+  database clean-up regardless of tags set for said scenario.
 
   Background:
     Given I have created a new Rails app and installed cucumber-rails
@@ -99,6 +102,35 @@ Feature: Choose javascript database strategy
       """
       2 scenarios (2 passed)
       5 steps (5 passed)
+      """
+
+  Scenario: Set the strategy to none and run a javascript scenario.
+    When I append to "features/env.rb" with:
+      """
+      DatabaseCleaner.strategy = :transaction
+      Cucumber::Rails::Database.javascript_strategy = :none
+      """
+    And I write to "features/widgets.feature" with:
+      """
+      Feature:
+        Background:
+          When I create 2 widgets
+
+        @javascript
+        Scenario:
+          When I create 3 widgets
+          Then I should have 5 widgets
+          And the DatabaseCleaner strategy should be transaction
+
+        Scenario:
+          Then I should have 2 widgets
+          And the DatabaseCleaner strategy should be transaction
+      """
+    And I run the cukes
+    Then the feature run should pass with:
+      """
+      2 scenarios (2 passed)
+      7 steps (7 passed)
       """
 
   Scenario: Set the strategy to truncation with an except option and run a javascript scenario.

--- a/lib/cucumber/rails.rb
+++ b/lib/cucumber/rails.rb
@@ -24,6 +24,7 @@ if called_from_env_rb
   require 'cucumber/rails/capybara'
   require 'cucumber/rails/database/strategy'
   require 'cucumber/rails/database/deletion_strategy'
+  require 'cucumber/rails/database/null_strategy'
   require 'cucumber/rails/database/shared_connection_strategy'
   require 'cucumber/rails/database/truncation_strategy'
   require 'cucumber/rails/database'

--- a/lib/cucumber/rails/database.rb
+++ b/lib/cucumber/rails/database.rb
@@ -49,7 +49,8 @@ module Cucumber
             truncation: TruncationStrategy,
             shared_connection: SharedConnectionStrategy,
             transaction: SharedConnectionStrategy,
-            deletion: DeletionStrategy
+            deletion: DeletionStrategy,
+            none: NullStrategy
           }
         end
 

--- a/lib/cucumber/rails/database/null_strategy.rb
+++ b/lib/cucumber/rails/database/null_strategy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Cucumber
+  module Rails
+    module Database
+      class NullStrategy
+        def before_js; end
+
+        def before_non_js; end
+
+        def after; end
+      end
+    end
+  end
+end

--- a/spec/cucumber/rails/database_spec.rb
+++ b/spec/cucumber/rails/database_spec.rb
@@ -3,6 +3,7 @@
 require 'database_cleaner'
 require 'cucumber/rails/database/strategy'
 require 'cucumber/rails/database/deletion_strategy'
+require 'cucumber/rails/database/null_strategy'
 require 'cucumber/rails/database/shared_connection_strategy'
 require 'cucumber/rails/database/truncation_strategy'
 require 'cucumber/rails/database'


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please choose a concise, descriptive name for your pull request. -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Presently there is no nice way to disable `@javascript` tag handling without writing a custom database strategy class. See #521

This PR adds a null database strategy to allow easily doing so by

```
Cucumber::Rails::Database.javascript_strategy = :none
```

I'm planning to add some other enhancements and documentation later to allow custom list of tags but having a null strategy is useful anyway and is a first step.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.