### PR TITLE
Add ruby 3.1 & drop ruby 2.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,21 +7,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1' ]
         gemfile: [ 'rails_5_0', 'rails_5_1', 'rails_5_2', 'rails_6_0', 'rails_6_1', 'rails_7_0' ]
         exclude:
           # Only test latest Rails (Of each major), on actively supported Ruby Versions
           # Only test latest Ruby with latest Rails versions (Of each major)
-          # 2.4  -> Only use legacy rails versions (5.0/5.1)
           # 2.5  -> Not 5.2/6.1
           # 2.6  -> Users of this should be using Rails 5.2+
           # 2.7  -> Users of this should be using Rails 5.2+
           # 3.0  -> Rails 6.1 and 7.0
           # 3.1  -> Only 7.0
-          - { ruby: '2.4', gemfile: 'rails_5_2' }
-          - { ruby: '2.4', gemfile: 'rails_6_0' }
-          - { ruby: '2.4', gemfile: 'rails_6_1' }
-          - { ruby: '2.4', gemfile: 'rails_7_0' }
           - { ruby: '2.5', gemfile: 'rails_5_2' }
           - { ruby: '2.5', gemfile: 'rails_6_1' }
           - { ruby: '2.5', gemfile: 'rails_7_0' }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.5.8', '2.6', '2.7', '3.0', '3.1' ]
         gemfile: [ 'rails_5_0', 'rails_5_1', 'rails_5_2', 'rails_6_0', 'rails_6_1', 'rails_7_0' ]
         exclude:
           # Only test latest Rails (Of each major), on actively supported Ruby Versions
@@ -17,9 +17,9 @@ jobs:
           # 2.7  -> Users of this should be using Rails 5.2+
           # 3.0  -> Rails 6.1 and 7.0
           # 3.1  -> Only 7.0
-          - { ruby: '2.5', gemfile: 'rails_5_2' }
-          - { ruby: '2.5', gemfile: 'rails_6_1' }
-          - { ruby: '2.5', gemfile: 'rails_7_0' }
+          - { ruby: '2.5.8', gemfile: 'rails_5_2' }
+          - { ruby: '2.5.8', gemfile: 'rails_6_1' }
+          - { ruby: '2.5.8', gemfile: 'rails_7_0' }
           - { ruby: '2.6', gemfile: 'rails_5_0' }
           - { ruby: '2.6', gemfile: 'rails_5_1' }
           - { ruby: '2.6', gemfile: 'rails_7_0' }
@@ -45,9 +45,9 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake spec
       - run: bundle exec rubocop
-      # ruby-2.5.9 has issues running bundle install during specs.
+      # ruby-2.5.8 and 2.5.9 has issues running bundle install during specs.
       # see errors here https://github.com/mgrunberg/cucumber-rails/runs/4824503004?check_suite_focus=true
       # seems incompatibility with psych gem and rubygems version.
       - run: gem update --system
-        if: matrix.ruby == '2.5'
+        if: matrix.ruby == '2.5.8'
       - run: bundle exec rake cucumber

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1' ]
         gemfile: [ 'rails_5_0', 'rails_5_1', 'rails_5_2', 'rails_6_0', 'rails_6_1', 'rails_7_0' ]
         exclude:
           # Only test latest Rails (Of each major), on actively supported Ruby Versions
@@ -16,7 +16,8 @@ jobs:
           # 2.5  -> Not 5.2/6.1
           # 2.6  -> Users of this should be using Rails 5.2+
           # 2.7  -> Users of this should be using Rails 5.2+
-          # 3.0  -> Only Rails 6.1
+          # 3.0  -> Rails 6.1 and 7.0
+          # 3.1  -> Only 7.0
           - { ruby: '2.4', gemfile: 'rails_5_2' }
           - { ruby: '2.4', gemfile: 'rails_6_0' }
           - { ruby: '2.4', gemfile: 'rails_6_1' }
@@ -33,6 +34,11 @@ jobs:
           - { ruby: '3.0', gemfile: 'rails_5_1' }
           - { ruby: '3.0', gemfile: 'rails_5_2' }
           - { ruby: '3.0', gemfile: 'rails_6_0' }
+          - { ruby: '3.1', gemfile: 'rails_5_0' }
+          - { ruby: '3.1', gemfile: 'rails_5_1' }
+          - { ruby: '3.1', gemfile: 'rails_5_2' }
+          - { ruby: '3.1', gemfile: 'rails_6_0' }
+          - { ruby: '3.1', gemfile: 'rails_6_1' }
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,3 +48,7 @@ Style/RegexpLiteral:
 
 RSpec/MessageSpies:
   EnforcedStyle: receive
+
+# TODO: investigate changes to release process and then enable MFA (https://guides.rubygems.org/mfa-requirement-opt-in/)
+Gemspec/RequireMFA:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
   Exclude:
     # These are auto-generated from a load of features that use aruba

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ on how to contribute to Cucumber.
 ### New Features
 
 * Added `:none` option for `javascript_strategy` which indicates no special handling of `@javascript` tagged tests ([#522](https://github.com/cucumber/cucumber-rails/pull/522) [akostadinov])
+* Added Ruby 3.1 support ([#529](https://github.com/cucumber/cucumber-rails/pull/529) [mgrunberg])
 
 ### Changed
 
-*
+* Dropped Ruby 2.4 support ([#529](https://github.com/cucumber/cucumber-rails/pull/529) [mgrunberg])
 
 ### Fixed
 

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -2,7 +2,7 @@
 
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 
-Gem::Specification.new do |s| # rubocop:disable Gemspec/RequireMFA
+Gem::Specification.new do |s|
   s.name        = 'cucumber-rails'
   s.version     = '2.4.0'
   s.authors     = ['Aslak Hellesøy', 'Dennis Blöte', 'Rob Holland']

--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -2,7 +2,7 @@
 
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Gemspec/RequireMFA
   s.name        = 'cucumber-rails'
   s.version     = '2.4.0'
   s.authors     = ['Aslak Hellesøy', 'Dennis Blöte', 'Rob Holland']
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('database_cleaner', ['>= 1.8', '< 3.0'])
   s.add_development_dependency('rake', '>= 12.0')
   s.add_development_dependency('rspec', '~> 3.6')
-  s.add_development_dependency('rubocop', '~> 1.7.0')
+  s.add_development_dependency('rubocop', '~> 1.24.0')
   s.add_development_dependency('rubocop-packaging', '~> 0.5.1')
   s.add_development_dependency('rubocop-performance', '~> 1.10.2')
   s.add_development_dependency('rubocop-rspec', '~> 2.2.0')
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rdoc', '>= 6.0')
   s.add_development_dependency('yard', '~> 0.9.10')
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.rubygems_version = '>= 1.6.1'
   s.require_path     = 'lib'
   s.files            = Dir['lib/**/*', 'CHANGELOG.md', 'CONTRIBUTING.md', 'LICENSE', 'README.md']

--- a/dev_tasks/yard/default/layout/html/setup.rb
+++ b/dev_tasks/yard/default/layout/html/setup.rb
@@ -4,6 +4,6 @@ def init
   super
   options[:serializer].serialize(
     '/images/bubble_32x32.png',
-    IO.read("#{File.dirname(__FILE__)}/bubble_32x32.png")
+    File.read("#{File.dirname(__FILE__)}/bubble_32x32.png")
   )
 end

--- a/lib/generators/cucumber/install_generator.rb
+++ b/lib/generators/cucumber/install_generator.rb
@@ -61,15 +61,15 @@ module Cucumber
     protected
 
     def embed_file(source, indent = '')
-      IO.read(File.join(self.class.source_root, source)).gsub(/^/, indent)
+      File.read(File.join(self.class.source_root, source)).gsub(/^/, indent)
     end
 
     def embed_template(source, indent = '')
       template = File.join(self.class.source_root, source)
       if RUBY_VERSION >= '2.6'
-        ERB.new(IO.read(template), trim_mode: '-').result(binding).gsub(/^/, indent)
+        ERB.new(File.read(template), trim_mode: '-').result(binding).gsub(/^/, indent)
       else
-        ERB.new(IO.read(template), nil, '-').result(binding).gsub(/^/, indent)
+        ERB.new(File.read(template), nil, '-').result(binding).gsub(/^/, indent)
       end
     end
   end


### PR DESCRIPTION
## Summary

- Target 2.5+ in gemspec, RuboCop config
- Fix new RuboCop offense
- Add Ruby 3.1 to github actions matrix

## Details

Rubocop requires an upgrade to 1.22.1 or higher to run on Ruby 3.1. Older versions generate the following error
```
An error occurred while Layout/BlockAlignment cop was inspecting cucumber-rails/features/support/aruba.rb:3:0. 
```
Rubocop 1.22.1 doesn't support ruby 2.4. Since ruby 2.4 EOL date is 2020-03-31 (almost two years ago) dropping support to add the latest ruby seems a good call.

The PR also downgrades ruby 2.5 version from 2.5.9 to 2.5.8. The reason is the following. Upgrading rubocop introduced a new dependency `unicode-display_width`. Bundler is unable to download it due `ArgumentError: wrong number of arguments (given 4, expected 1)`.  According to [this comment](https://github.com/rubygems/rubygems/issues/4976#issuecomment-940024665) the problem is that we're using an old version of rubygems that does not support psych 4. 
Ruby installation and bundle install is done by ruby/setup-ruby in a single step. I couldn't find a way to upgrade rubygems before running bundle install without extending the action .
Ruby 2.5.8 doesn't have this problem. Considering that ruby 2.5 EOL date is 2021-03-31 (almost a year ago), I believe it's fine to run tests against 2.5.8

## Motivation and Context

Add support to latest ruby version

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

