### PR TITLE
Use `required_rubygems_version` instead of `rubygems_version`

### DIFF
--- a/cucumber-rails.gemspec
+++ b/cucumber-rails.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('yard', '~> 0.9.10')
 
   s.required_ruby_version = '>= 2.5.0'
-  s.rubygems_version = '>= 1.6.1'
+  s.required_rubygems_version = '>= 1.6.1'
   s.require_path     = 'lib'
   s.files            = Dir['lib/**/*', 'CHANGELOG.md', 'CONTRIBUTING.md', 'LICENSE', 'README.md']
 end


### PR DESCRIPTION
## Summary

Correct `rubygems_version` to `required_rubygems_version` in cucumbe-rails.gemspec.

## Details

`rubygems_version` was used, probably a mistake for `required_rubygems_version`.


## Motivation and Context

Because `rubygems_version` should not be set.
refs: https://github.com/rubygems/rubygems/blob/cc6f96aa0c1c99d94363d12884001a2de28da033/lib/rubygems/specification.rb#L530-L534


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
