### PR TITLE
Use GitHub Actions badge in README.md [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cucumber-Rails
 
 [![Gem Version](https://badge.fury.io/rb/cucumber-rails.svg)](http://badge.fury.io/rb/cucumber-rails)
-[![Build Status](https://github.com/cucumber/cucumber-rails/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/cucumber/cucumber-rails/actions/workflows/build.yml)
+[![build](https://github.com/cucumber/cucumber-rails/actions/workflows/test.yml/badge.svg)](https://github.com/cucumber/cucumber-rails/actions/workflows/test.yml)
 [![Code Climate](https://codeclimate.com/github/cucumber/cucumber-rails.svg)](https://codeclimate.com/github/cucumber/cucumber-rails)
 [![Open Source Helpers](https://www.codetriage.com/cucumber/cucumber-rails/badges/users.svg)](https://www.codetriage.com/cucumber/cucumber-rails)
 [![pull requests](https://oselvar.com/api/badge?label=pull%20requests&csvUrl=https%3A%2F%2Fraw.githubusercontent.com%2Fcucumber%2Foselvar-github-metrics%2Fmain%2Fdata%2Fcucumber%2Fcucumber-rails%2FpullRequests.csv)](https://oselvar.com/github/cucumber/oselvar-github-metrics/main/cucumber/cucumber-rails)


### PR DESCRIPTION


### 🤔 What's changed?

This changes the URL to the build status badge to a working one.

### ⚡️ What's your motivation? 

There was a broken image in the README.
### 🏷️ What kind of change is this?


- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

 
- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
 
 
 

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
