### PR TITLE
CI: Attempt to let ruby/setup-ruby pick Bundler, RubyGems

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: '2.4.19'
-          rubygems: latest
           bundler-cache: true
       - run: bundle exec rake spec
       - run: bundle exec rubocop


### PR DESCRIPTION


### 🤔 What's changed?


This PR changes CI to let ruby/setup-ruby decide which Bundler is right and works for a given Ruby version.


### ⚡️ What's your motivation? 

I wanted the project to have fewer settings to maintain.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### ♻️ Anything particular you want feedback on?

If there were any specific context I am missing re: keeping a specific version.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)

