### PR TITLE
Stop printing warning when `config.cache_classes` is set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This file is intended to be modified using the [`changelog`](https://github.com/cucumber/changelog) command-line tool.
 
 ## [Unreleased]
+### Removed
+- Stop printing a warning about `config.cache_classes` being set to `false`
 
 ## [4.0.0] - 2025-09-01
 ### Changed

--- a/lib/cucumber/rails.rb
+++ b/lib/cucumber/rails.rb
@@ -12,16 +12,6 @@ if called_from_env_rb
   require File.expand_path("#{ENV.fetch('RAILS_ROOT')}/config/environment")
   require 'cucumber/rails/action_dispatch'
   require 'rails/test_help'
-
-  unless Rails.application.config.cache_classes || defined?(Spring)
-    warn <<~MESSAGE
-      WARNING: You have set Rails' config.cache_classes to false (Spring needs cache_classes set to false).
-      This is known to cause problems with database transactions.
-
-      Set config.cache_classes to true if you want to use transactions.
-    MESSAGE
-  end
-
   require 'cucumber/rails/world'
   require 'cucumber/rails/hooks'
   require 'cucumber/rails/capybara'


### PR DESCRIPTION
### 🤔 What's changed?

The initial warning was from 16 years ago from a bug report that no longer exists, for Rails 2 and is no longer relevant.
This fixed #597

### ⚡️ What's your motivation? 

Removes unnecessary noise.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x]  I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
