### PR TITLE
Fix broken CI badge after workflow rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cucumber-Rails
 
 [![Gem Version](https://badge.fury.io/rb/cucumber-rails.svg)](http://badge.fury.io/rb/cucumber-rails)
-[![build](https://github.com/cucumber/cucumber-rails/actions/workflows/test.yml/badge.svg)](https://github.com/cucumber/cucumber-rails/actions/workflows/test.yml)
+[![build](https://github.com/cucumber/cucumber-rails/actions/workflows/test-ruby.yaml/badge.svg)](https://github.com/cucumber/cucumber-rails/actions/workflows/test-ruby.yaml)
 [![Open Source Helpers](https://www.codetriage.com/cucumber/cucumber-rails/badges/users.svg)](https://www.codetriage.com/cucumber/cucumber-rails)
 
 Cucumber-Rails brings Cucumber to Rails 6.1, 7.x, and 8.x.


### PR DESCRIPTION
The build badge in README.md still pointed to `test.yml` but the workflow was renamed to `test-ruby.yaml` across two commits that did not update the badge reference:

- `b04063f` Refactor Github actions to follow Cucumber org conventions
- `700d3b8` Prefer .yaml over .yml for GitHub actions

This updates the badge URL to point to the correct workflow file.